### PR TITLE
Load ore probabilities from server table

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,6 +453,95 @@ section[id^="tab-"].active{ display:block; }
       { key:'Diamond', name:'다이아',   color:'#b9f6ff', hp:3000,  value:180, weight: 2,  tier:6, minFloor:22 },
     ];
 
+    const ORE_BY_KEY = {};
+    for(const oreDef of ORES){ ORE_BY_KEY[oreDef.key] = oreDef; }
+
+    const ORE_TABLE_URL = `ore_probabilities.json?v=${VERSION}`;
+    let oreTableLoaded = false;
+    let oreTablePromise = null;
+    let oreWeightTable = null;
+    let oreTableFloors = [];
+
+    function normalizeOreTableEntry(entry){
+      if(Array.isArray(entry)){
+        const [key, weight] = entry;
+        const weightNum = Number(weight);
+        if(typeof key === 'string' && Number.isFinite(weightNum)){
+          return { key, weight: weightNum };
+        }
+        return null;
+      }
+      if(entry && typeof entry === 'object'){
+        const key = entry.key || entry.id || entry.type;
+        const rawWeight = entry.weight ?? entry.w ?? entry.value;
+        const weightNum = Number(rawWeight);
+        if(typeof key === 'string' && Number.isFinite(weightNum)){
+          return { key, weight: weightNum };
+        }
+      }
+      return null;
+    }
+
+    function applyOreTableData(data){
+      if(!data || typeof data !== 'object') return false;
+      const floors = data.floors && typeof data.floors === 'object' ? data.floors : data;
+      const table = new Map();
+      const floorKeys = [];
+      for(const key of Object.keys(floors)){
+        const floorNum = Number(key);
+        if(!Number.isFinite(floorNum)) continue;
+        const raw = floors[key];
+        let entries = [];
+        if(Array.isArray(raw)){
+          entries = raw.map(normalizeOreTableEntry).filter(Boolean);
+        } else if(raw && typeof raw === 'object'){
+          entries = Object.keys(raw).map(k=> normalizeOreTableEntry({ key:k, weight: raw[k] })).filter(Boolean);
+        }
+        if(entries.length){
+          table.set(floorNum, entries);
+          floorKeys.push(floorNum);
+        }
+      }
+      if(!floorKeys.length) return false;
+      floorKeys.sort((a,b)=>a-b);
+      oreWeightTable = table;
+      oreTableFloors = floorKeys;
+      return true;
+    }
+
+    async function ensureOreTable(){
+      if(oreTableLoaded) return oreWeightTable;
+      if(typeof fetch !== 'function'){ oreTableLoaded = true; return null; }
+      if(!oreTablePromise){
+        oreTablePromise = fetch(ORE_TABLE_URL, { cache:'no-store' })
+          .then(res=>{
+            if(!res.ok) throw new Error(`HTTP ${res.status}`);
+            return res.json();
+          })
+          .then(data=>{
+            if(!applyOreTableData(data)){
+              console.warn('Ore probability table missing or invalid data');
+            }
+            oreTableLoaded = true;
+            return oreWeightTable;
+          })
+          .catch(err=>{
+            console.warn('Failed to load ore probability table', err);
+            oreTableLoaded = true;
+            oreWeightTable = null;
+            oreTableFloors = [];
+            return null;
+          });
+      }
+      try{
+        return await oreTablePromise;
+      }catch(err){
+        return null;
+      }
+    }
+
+    ensureOreTable();
+
     for(const o of ORES){ state.inventory[o.key]=state.inventory[o.key]||0; state.loot[o.key]=0; state.upgrades.oreMul[o.key]=state.upgrades.oreMul[o.key]||0; }
 
     const PET = { moveSpeed: 220, atkInterval: 0.55, sepRadius: 24, atkRange: 18 };
@@ -637,17 +726,41 @@ section[id^="tab-"].active{ display:block; }
     window.requestPlayGamesStatus = refreshPlayGamesStatus;
 
     function randWeighted(items){ const total = items.reduce((a,b)=>a+b.weight,0); let r = Math.random()*total; for(const it of items){ if((r-=it.weight) <= 0) return it; } return items[0]; }
-      function eligibleOresForFloor(f){
-        const luck = state.aether?.luck||0;
-        return ORES.filter(o=> f >= o.minFloor).map(o=>{
-          const bonus = Math.max(0, f - o.minFloor);
-          const tierBoost = 1 + (o.tier-1)*0.03*bonus;
-          const rareMul = 1 + luck*0.08*(o.tier-1);
-          let weight = o.weight * tierBoost * rareMul;
-          if(o.key==='Silver' && f<3){ weight *= (f===1 ? 0.1 : 0.3); }
-          return { ...o, weight: Math.max(1, Math.round(weight)) };
-        });
+    function tableWeightsForFloor(f){
+      if(!oreWeightTable || !oreTableFloors.length) return null;
+      let candidate = null;
+      for(const floor of oreTableFloors){
+        if(floor>f) break;
+        candidate = floor;
       }
+      if(candidate===null) return null;
+      return oreWeightTable.get(candidate) || null;
+    }
+    function eligibleOresForFloor(f){
+      const luck = state.aether?.luck||0;
+      const tableEntries = tableWeightsForFloor(f);
+      if(tableEntries && tableEntries.length){
+        const pool = [];
+        for(const entry of tableEntries){
+          const ore = ORE_BY_KEY[entry.key];
+          if(!ore) continue;
+          let weight = Number(entry.weight);
+          if(!Number.isFinite(weight) || weight<=0) weight = 1;
+          const rareMul = 1 + luck*0.08*(ore.tier-1);
+          weight = Math.max(1, Math.round(weight * rareMul));
+          pool.push({ ...ore, weight });
+        }
+        if(pool.length) return pool;
+      }
+      return ORES.filter(o=> f >= o.minFloor).map(o=>{
+        const bonus = Math.max(0, f - o.minFloor);
+        const tierBoost = 1 + (o.tier-1)*0.03*bonus;
+        const rareMul = 1 + luck*0.08*(o.tier-1);
+        let weight = o.weight * tierBoost * rareMul;
+        if(o.key==='Silver' && f<3){ weight *= (f===1 ? 0.1 : 0.3); }
+        return { ...o, weight: Math.max(1, Math.round(weight)) };
+      });
+    }
     function gridRect(){
       const r = gridEl.getBoundingClientRect();
       if(r.width && r.height){
@@ -865,7 +978,8 @@ section[id^="tab-"].active{ display:block; }
     function floorHpMul(){ return 1 + 0.18*(state.floor-1); }
     function floorValMul(){ return 1 + 0.12*(state.floor-1); }
 
-    function startRun(){
+    async function startRun(){
+      await ensureOreTable();
       if(state.inRun) return;
       state.inRun = true;
       state.etherSpawned=false;
@@ -938,6 +1052,7 @@ section[id^="tab-"].active{ display:block; }
       const empties = state.grid.map((v,i)=> v? null : i).filter(v=>v!==null); if(empties.length===0) return;
       const idx = empties[Math.floor(Math.random()*empties.length)];
       const pool = eligibleOresForFloor(state.floor);
+      if(!pool || !pool.length){ console.warn('No ore weights available for floor', state.floor); return; }
       const base = randWeighted(pool);
       const elapsed = (performance.now() - state.runStartTs)/1000;
       const growth = 1 + 0.02 * Math.max(0, Math.floor(elapsed));

--- a/ore_probabilities.json
+++ b/ore_probabilities.json
@@ -1,0 +1,1969 @@
+{
+  "version": "1",
+  "floors": {
+    "1": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Silver",
+        "weight": 2
+      }
+    ],
+    "2": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 30
+      },
+      {
+        "key": "Silver",
+        "weight": 7
+      }
+    ],
+    "3": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 31
+      },
+      {
+        "key": "Silver",
+        "weight": 25
+      }
+    ],
+    "4": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 32
+      },
+      {
+        "key": "Silver",
+        "weight": 26
+      }
+    ],
+    "5": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 33
+      },
+      {
+        "key": "Silver",
+        "weight": 27
+      },
+      {
+        "key": "Gold",
+        "weight": 16
+      }
+    ],
+    "6": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 34
+      },
+      {
+        "key": "Silver",
+        "weight": 29
+      },
+      {
+        "key": "Gold",
+        "weight": 17
+      }
+    ],
+    "7": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 35
+      },
+      {
+        "key": "Silver",
+        "weight": 30
+      },
+      {
+        "key": "Gold",
+        "weight": 18
+      }
+    ],
+    "8": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 35
+      },
+      {
+        "key": "Silver",
+        "weight": 31
+      },
+      {
+        "key": "Gold",
+        "weight": 19
+      },
+      {
+        "key": "Platinum",
+        "weight": 10
+      }
+    ],
+    "9": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 36
+      },
+      {
+        "key": "Silver",
+        "weight": 33
+      },
+      {
+        "key": "Gold",
+        "weight": 20
+      },
+      {
+        "key": "Platinum",
+        "weight": 11
+      }
+    ],
+    "10": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 37
+      },
+      {
+        "key": "Silver",
+        "weight": 34
+      },
+      {
+        "key": "Gold",
+        "weight": 21
+      },
+      {
+        "key": "Platinum",
+        "weight": 12
+      },
+      {
+        "key": "Sapphire",
+        "weight": 7
+      }
+    ],
+    "11": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 38
+      },
+      {
+        "key": "Silver",
+        "weight": 35
+      },
+      {
+        "key": "Gold",
+        "weight": 22
+      },
+      {
+        "key": "Platinum",
+        "weight": 13
+      },
+      {
+        "key": "Sapphire",
+        "weight": 8
+      }
+    ],
+    "12": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 39
+      },
+      {
+        "key": "Silver",
+        "weight": 37
+      },
+      {
+        "key": "Gold",
+        "weight": 23
+      },
+      {
+        "key": "Platinum",
+        "weight": 14
+      },
+      {
+        "key": "Sapphire",
+        "weight": 8
+      },
+      {
+        "key": "Ruby",
+        "weight": 6
+      }
+    ],
+    "13": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 40
+      },
+      {
+        "key": "Silver",
+        "weight": 38
+      },
+      {
+        "key": "Gold",
+        "weight": 24
+      },
+      {
+        "key": "Platinum",
+        "weight": 15
+      },
+      {
+        "key": "Sapphire",
+        "weight": 9
+      },
+      {
+        "key": "Ruby",
+        "weight": 7
+      }
+    ],
+    "14": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 41
+      },
+      {
+        "key": "Silver",
+        "weight": 39
+      },
+      {
+        "key": "Gold",
+        "weight": 25
+      },
+      {
+        "key": "Platinum",
+        "weight": 15
+      },
+      {
+        "key": "Sapphire",
+        "weight": 10
+      },
+      {
+        "key": "Ruby",
+        "weight": 7
+      }
+    ],
+    "15": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 42
+      },
+      {
+        "key": "Silver",
+        "weight": 40
+      },
+      {
+        "key": "Gold",
+        "weight": 26
+      },
+      {
+        "key": "Platinum",
+        "weight": 16
+      },
+      {
+        "key": "Sapphire",
+        "weight": 10
+      },
+      {
+        "key": "Ruby",
+        "weight": 8
+      },
+      {
+        "key": "Emerald",
+        "weight": 5
+      }
+    ],
+    "16": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 43
+      },
+      {
+        "key": "Silver",
+        "weight": 42
+      },
+      {
+        "key": "Gold",
+        "weight": 27
+      },
+      {
+        "key": "Platinum",
+        "weight": 17
+      },
+      {
+        "key": "Sapphire",
+        "weight": 11
+      },
+      {
+        "key": "Ruby",
+        "weight": 9
+      },
+      {
+        "key": "Emerald",
+        "weight": 6
+      }
+    ],
+    "17": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 44
+      },
+      {
+        "key": "Silver",
+        "weight": 43
+      },
+      {
+        "key": "Gold",
+        "weight": 28
+      },
+      {
+        "key": "Platinum",
+        "weight": 18
+      },
+      {
+        "key": "Sapphire",
+        "weight": 11
+      },
+      {
+        "key": "Ruby",
+        "weight": 10
+      },
+      {
+        "key": "Emerald",
+        "weight": 6
+      }
+    ],
+    "18": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 44
+      },
+      {
+        "key": "Silver",
+        "weight": 44
+      },
+      {
+        "key": "Gold",
+        "weight": 28
+      },
+      {
+        "key": "Platinum",
+        "weight": 19
+      },
+      {
+        "key": "Sapphire",
+        "weight": 12
+      },
+      {
+        "key": "Ruby",
+        "weight": 10
+      },
+      {
+        "key": "Emerald",
+        "weight": 7
+      },
+      {
+        "key": "Mythril",
+        "weight": 3
+      }
+    ],
+    "19": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 45
+      },
+      {
+        "key": "Silver",
+        "weight": 46
+      },
+      {
+        "key": "Gold",
+        "weight": 29
+      },
+      {
+        "key": "Platinum",
+        "weight": 20
+      },
+      {
+        "key": "Sapphire",
+        "weight": 13
+      },
+      {
+        "key": "Ruby",
+        "weight": 11
+      },
+      {
+        "key": "Emerald",
+        "weight": 7
+      },
+      {
+        "key": "Mythril",
+        "weight": 3
+      }
+    ],
+    "20": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 46
+      },
+      {
+        "key": "Silver",
+        "weight": 47
+      },
+      {
+        "key": "Gold",
+        "weight": 30
+      },
+      {
+        "key": "Platinum",
+        "weight": 21
+      },
+      {
+        "key": "Sapphire",
+        "weight": 13
+      },
+      {
+        "key": "Ruby",
+        "weight": 12
+      },
+      {
+        "key": "Emerald",
+        "weight": 8
+      },
+      {
+        "key": "Mythril",
+        "weight": 4
+      }
+    ],
+    "21": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 47
+      },
+      {
+        "key": "Silver",
+        "weight": 48
+      },
+      {
+        "key": "Gold",
+        "weight": 31
+      },
+      {
+        "key": "Platinum",
+        "weight": 22
+      },
+      {
+        "key": "Sapphire",
+        "weight": 14
+      },
+      {
+        "key": "Ruby",
+        "weight": 12
+      },
+      {
+        "key": "Emerald",
+        "weight": 9
+      },
+      {
+        "key": "Mythril",
+        "weight": 4
+      }
+    ],
+    "22": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 48
+      },
+      {
+        "key": "Silver",
+        "weight": 50
+      },
+      {
+        "key": "Gold",
+        "weight": 32
+      },
+      {
+        "key": "Platinum",
+        "weight": 23
+      },
+      {
+        "key": "Sapphire",
+        "weight": 15
+      },
+      {
+        "key": "Ruby",
+        "weight": 13
+      },
+      {
+        "key": "Emerald",
+        "weight": 9
+      },
+      {
+        "key": "Mythril",
+        "weight": 5
+      },
+      {
+        "key": "Diamond",
+        "weight": 2
+      }
+    ],
+    "23": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 49
+      },
+      {
+        "key": "Silver",
+        "weight": 51
+      },
+      {
+        "key": "Gold",
+        "weight": 33
+      },
+      {
+        "key": "Platinum",
+        "weight": 23
+      },
+      {
+        "key": "Sapphire",
+        "weight": 15
+      },
+      {
+        "key": "Ruby",
+        "weight": 14
+      },
+      {
+        "key": "Emerald",
+        "weight": 10
+      },
+      {
+        "key": "Mythril",
+        "weight": 5
+      },
+      {
+        "key": "Diamond",
+        "weight": 2
+      }
+    ],
+    "24": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 50
+      },
+      {
+        "key": "Silver",
+        "weight": 52
+      },
+      {
+        "key": "Gold",
+        "weight": 34
+      },
+      {
+        "key": "Platinum",
+        "weight": 24
+      },
+      {
+        "key": "Sapphire",
+        "weight": 16
+      },
+      {
+        "key": "Ruby",
+        "weight": 15
+      },
+      {
+        "key": "Emerald",
+        "weight": 10
+      },
+      {
+        "key": "Mythril",
+        "weight": 6
+      },
+      {
+        "key": "Diamond",
+        "weight": 3
+      }
+    ],
+    "25": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 51
+      },
+      {
+        "key": "Silver",
+        "weight": 54
+      },
+      {
+        "key": "Gold",
+        "weight": 35
+      },
+      {
+        "key": "Platinum",
+        "weight": 25
+      },
+      {
+        "key": "Sapphire",
+        "weight": 16
+      },
+      {
+        "key": "Ruby",
+        "weight": 15
+      },
+      {
+        "key": "Emerald",
+        "weight": 11
+      },
+      {
+        "key": "Mythril",
+        "weight": 6
+      },
+      {
+        "key": "Diamond",
+        "weight": 3
+      }
+    ],
+    "26": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 52
+      },
+      {
+        "key": "Silver",
+        "weight": 55
+      },
+      {
+        "key": "Gold",
+        "weight": 36
+      },
+      {
+        "key": "Platinum",
+        "weight": 26
+      },
+      {
+        "key": "Sapphire",
+        "weight": 17
+      },
+      {
+        "key": "Ruby",
+        "weight": 16
+      },
+      {
+        "key": "Emerald",
+        "weight": 12
+      },
+      {
+        "key": "Mythril",
+        "weight": 7
+      },
+      {
+        "key": "Diamond",
+        "weight": 3
+      }
+    ],
+    "27": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 53
+      },
+      {
+        "key": "Silver",
+        "weight": 56
+      },
+      {
+        "key": "Gold",
+        "weight": 37
+      },
+      {
+        "key": "Platinum",
+        "weight": 27
+      },
+      {
+        "key": "Sapphire",
+        "weight": 18
+      },
+      {
+        "key": "Ruby",
+        "weight": 17
+      },
+      {
+        "key": "Emerald",
+        "weight": 12
+      },
+      {
+        "key": "Mythril",
+        "weight": 7
+      },
+      {
+        "key": "Diamond",
+        "weight": 4
+      }
+    ],
+    "28": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 53
+      },
+      {
+        "key": "Silver",
+        "weight": 58
+      },
+      {
+        "key": "Gold",
+        "weight": 38
+      },
+      {
+        "key": "Platinum",
+        "weight": 28
+      },
+      {
+        "key": "Sapphire",
+        "weight": 18
+      },
+      {
+        "key": "Ruby",
+        "weight": 18
+      },
+      {
+        "key": "Emerald",
+        "weight": 13
+      },
+      {
+        "key": "Mythril",
+        "weight": 8
+      },
+      {
+        "key": "Diamond",
+        "weight": 4
+      }
+    ],
+    "29": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 54
+      },
+      {
+        "key": "Silver",
+        "weight": 59
+      },
+      {
+        "key": "Gold",
+        "weight": 39
+      },
+      {
+        "key": "Platinum",
+        "weight": 29
+      },
+      {
+        "key": "Sapphire",
+        "weight": 19
+      },
+      {
+        "key": "Ruby",
+        "weight": 18
+      },
+      {
+        "key": "Emerald",
+        "weight": 13
+      },
+      {
+        "key": "Mythril",
+        "weight": 8
+      },
+      {
+        "key": "Diamond",
+        "weight": 4
+      }
+    ],
+    "30": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 55
+      },
+      {
+        "key": "Silver",
+        "weight": 60
+      },
+      {
+        "key": "Gold",
+        "weight": 40
+      },
+      {
+        "key": "Platinum",
+        "weight": 30
+      },
+      {
+        "key": "Sapphire",
+        "weight": 20
+      },
+      {
+        "key": "Ruby",
+        "weight": 19
+      },
+      {
+        "key": "Emerald",
+        "weight": 14
+      },
+      {
+        "key": "Mythril",
+        "weight": 8
+      },
+      {
+        "key": "Diamond",
+        "weight": 4
+      }
+    ],
+    "31": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 56
+      },
+      {
+        "key": "Silver",
+        "weight": 62
+      },
+      {
+        "key": "Gold",
+        "weight": 41
+      },
+      {
+        "key": "Platinum",
+        "weight": 31
+      },
+      {
+        "key": "Sapphire",
+        "weight": 20
+      },
+      {
+        "key": "Ruby",
+        "weight": 20
+      },
+      {
+        "key": "Emerald",
+        "weight": 15
+      },
+      {
+        "key": "Mythril",
+        "weight": 9
+      },
+      {
+        "key": "Diamond",
+        "weight": 5
+      }
+    ],
+    "32": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 57
+      },
+      {
+        "key": "Silver",
+        "weight": 63
+      },
+      {
+        "key": "Gold",
+        "weight": 42
+      },
+      {
+        "key": "Platinum",
+        "weight": 32
+      },
+      {
+        "key": "Sapphire",
+        "weight": 21
+      },
+      {
+        "key": "Ruby",
+        "weight": 20
+      },
+      {
+        "key": "Emerald",
+        "weight": 15
+      },
+      {
+        "key": "Mythril",
+        "weight": 9
+      },
+      {
+        "key": "Diamond",
+        "weight": 5
+      }
+    ],
+    "33": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 58
+      },
+      {
+        "key": "Silver",
+        "weight": 64
+      },
+      {
+        "key": "Gold",
+        "weight": 43
+      },
+      {
+        "key": "Platinum",
+        "weight": 33
+      },
+      {
+        "key": "Sapphire",
+        "weight": 21
+      },
+      {
+        "key": "Ruby",
+        "weight": 21
+      },
+      {
+        "key": "Emerald",
+        "weight": 16
+      },
+      {
+        "key": "Mythril",
+        "weight": 10
+      },
+      {
+        "key": "Diamond",
+        "weight": 5
+      }
+    ],
+    "34": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 59
+      },
+      {
+        "key": "Silver",
+        "weight": 66
+      },
+      {
+        "key": "Gold",
+        "weight": 44
+      },
+      {
+        "key": "Platinum",
+        "weight": 33
+      },
+      {
+        "key": "Sapphire",
+        "weight": 22
+      },
+      {
+        "key": "Ruby",
+        "weight": 22
+      },
+      {
+        "key": "Emerald",
+        "weight": 16
+      },
+      {
+        "key": "Mythril",
+        "weight": 10
+      },
+      {
+        "key": "Diamond",
+        "weight": 6
+      }
+    ],
+    "35": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 60
+      },
+      {
+        "key": "Silver",
+        "weight": 67
+      },
+      {
+        "key": "Gold",
+        "weight": 45
+      },
+      {
+        "key": "Platinum",
+        "weight": 34
+      },
+      {
+        "key": "Sapphire",
+        "weight": 23
+      },
+      {
+        "key": "Ruby",
+        "weight": 23
+      },
+      {
+        "key": "Emerald",
+        "weight": 17
+      },
+      {
+        "key": "Mythril",
+        "weight": 11
+      },
+      {
+        "key": "Diamond",
+        "weight": 6
+      }
+    ],
+    "36": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 61
+      },
+      {
+        "key": "Silver",
+        "weight": 68
+      },
+      {
+        "key": "Gold",
+        "weight": 46
+      },
+      {
+        "key": "Platinum",
+        "weight": 35
+      },
+      {
+        "key": "Sapphire",
+        "weight": 23
+      },
+      {
+        "key": "Ruby",
+        "weight": 23
+      },
+      {
+        "key": "Emerald",
+        "weight": 18
+      },
+      {
+        "key": "Mythril",
+        "weight": 11
+      },
+      {
+        "key": "Diamond",
+        "weight": 6
+      }
+    ],
+    "37": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 61
+      },
+      {
+        "key": "Silver",
+        "weight": 70
+      },
+      {
+        "key": "Gold",
+        "weight": 47
+      },
+      {
+        "key": "Platinum",
+        "weight": 36
+      },
+      {
+        "key": "Sapphire",
+        "weight": 24
+      },
+      {
+        "key": "Ruby",
+        "weight": 24
+      },
+      {
+        "key": "Emerald",
+        "weight": 18
+      },
+      {
+        "key": "Mythril",
+        "weight": 12
+      },
+      {
+        "key": "Diamond",
+        "weight": 7
+      }
+    ],
+    "38": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 62
+      },
+      {
+        "key": "Silver",
+        "weight": 71
+      },
+      {
+        "key": "Gold",
+        "weight": 48
+      },
+      {
+        "key": "Platinum",
+        "weight": 37
+      },
+      {
+        "key": "Sapphire",
+        "weight": 25
+      },
+      {
+        "key": "Ruby",
+        "weight": 25
+      },
+      {
+        "key": "Emerald",
+        "weight": 19
+      },
+      {
+        "key": "Mythril",
+        "weight": 12
+      },
+      {
+        "key": "Diamond",
+        "weight": 7
+      }
+    ],
+    "39": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 63
+      },
+      {
+        "key": "Silver",
+        "weight": 72
+      },
+      {
+        "key": "Gold",
+        "weight": 49
+      },
+      {
+        "key": "Platinum",
+        "weight": 38
+      },
+      {
+        "key": "Sapphire",
+        "weight": 25
+      },
+      {
+        "key": "Ruby",
+        "weight": 25
+      },
+      {
+        "key": "Emerald",
+        "weight": 19
+      },
+      {
+        "key": "Mythril",
+        "weight": 12
+      },
+      {
+        "key": "Diamond",
+        "weight": 7
+      }
+    ],
+    "40": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 64
+      },
+      {
+        "key": "Silver",
+        "weight": 73
+      },
+      {
+        "key": "Gold",
+        "weight": 50
+      },
+      {
+        "key": "Platinum",
+        "weight": 39
+      },
+      {
+        "key": "Sapphire",
+        "weight": 26
+      },
+      {
+        "key": "Ruby",
+        "weight": 26
+      },
+      {
+        "key": "Emerald",
+        "weight": 20
+      },
+      {
+        "key": "Mythril",
+        "weight": 13
+      },
+      {
+        "key": "Diamond",
+        "weight": 7
+      }
+    ],
+    "41": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 65
+      },
+      {
+        "key": "Silver",
+        "weight": 75
+      },
+      {
+        "key": "Gold",
+        "weight": 51
+      },
+      {
+        "key": "Platinum",
+        "weight": 40
+      },
+      {
+        "key": "Sapphire",
+        "weight": 27
+      },
+      {
+        "key": "Ruby",
+        "weight": 27
+      },
+      {
+        "key": "Emerald",
+        "weight": 21
+      },
+      {
+        "key": "Mythril",
+        "weight": 13
+      },
+      {
+        "key": "Diamond",
+        "weight": 8
+      }
+    ],
+    "42": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 66
+      },
+      {
+        "key": "Silver",
+        "weight": 76
+      },
+      {
+        "key": "Gold",
+        "weight": 52
+      },
+      {
+        "key": "Platinum",
+        "weight": 41
+      },
+      {
+        "key": "Sapphire",
+        "weight": 27
+      },
+      {
+        "key": "Ruby",
+        "weight": 28
+      },
+      {
+        "key": "Emerald",
+        "weight": 21
+      },
+      {
+        "key": "Mythril",
+        "weight": 14
+      },
+      {
+        "key": "Diamond",
+        "weight": 8
+      }
+    ],
+    "43": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 67
+      },
+      {
+        "key": "Silver",
+        "weight": 77
+      },
+      {
+        "key": "Gold",
+        "weight": 52
+      },
+      {
+        "key": "Platinum",
+        "weight": 42
+      },
+      {
+        "key": "Sapphire",
+        "weight": 28
+      },
+      {
+        "key": "Ruby",
+        "weight": 28
+      },
+      {
+        "key": "Emerald",
+        "weight": 22
+      },
+      {
+        "key": "Mythril",
+        "weight": 14
+      },
+      {
+        "key": "Diamond",
+        "weight": 8
+      }
+    ],
+    "44": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 68
+      },
+      {
+        "key": "Silver",
+        "weight": 79
+      },
+      {
+        "key": "Gold",
+        "weight": 53
+      },
+      {
+        "key": "Platinum",
+        "weight": 42
+      },
+      {
+        "key": "Sapphire",
+        "weight": 28
+      },
+      {
+        "key": "Ruby",
+        "weight": 29
+      },
+      {
+        "key": "Emerald",
+        "weight": 22
+      },
+      {
+        "key": "Mythril",
+        "weight": 15
+      },
+      {
+        "key": "Diamond",
+        "weight": 9
+      }
+    ],
+    "45": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 69
+      },
+      {
+        "key": "Silver",
+        "weight": 80
+      },
+      {
+        "key": "Gold",
+        "weight": 54
+      },
+      {
+        "key": "Platinum",
+        "weight": 43
+      },
+      {
+        "key": "Sapphire",
+        "weight": 29
+      },
+      {
+        "key": "Ruby",
+        "weight": 30
+      },
+      {
+        "key": "Emerald",
+        "weight": 23
+      },
+      {
+        "key": "Mythril",
+        "weight": 15
+      },
+      {
+        "key": "Diamond",
+        "weight": 9
+      }
+    ],
+    "46": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 70
+      },
+      {
+        "key": "Silver",
+        "weight": 81
+      },
+      {
+        "key": "Gold",
+        "weight": 55
+      },
+      {
+        "key": "Platinum",
+        "weight": 44
+      },
+      {
+        "key": "Sapphire",
+        "weight": 30
+      },
+      {
+        "key": "Ruby",
+        "weight": 30
+      },
+      {
+        "key": "Emerald",
+        "weight": 24
+      },
+      {
+        "key": "Mythril",
+        "weight": 16
+      },
+      {
+        "key": "Diamond",
+        "weight": 9
+      }
+    ],
+    "47": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 70
+      },
+      {
+        "key": "Silver",
+        "weight": 83
+      },
+      {
+        "key": "Gold",
+        "weight": 56
+      },
+      {
+        "key": "Platinum",
+        "weight": 45
+      },
+      {
+        "key": "Sapphire",
+        "weight": 30
+      },
+      {
+        "key": "Ruby",
+        "weight": 31
+      },
+      {
+        "key": "Emerald",
+        "weight": 24
+      },
+      {
+        "key": "Mythril",
+        "weight": 16
+      },
+      {
+        "key": "Diamond",
+        "weight": 10
+      }
+    ],
+    "48": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 71
+      },
+      {
+        "key": "Silver",
+        "weight": 84
+      },
+      {
+        "key": "Gold",
+        "weight": 57
+      },
+      {
+        "key": "Platinum",
+        "weight": 46
+      },
+      {
+        "key": "Sapphire",
+        "weight": 31
+      },
+      {
+        "key": "Ruby",
+        "weight": 32
+      },
+      {
+        "key": "Emerald",
+        "weight": 25
+      },
+      {
+        "key": "Mythril",
+        "weight": 17
+      },
+      {
+        "key": "Diamond",
+        "weight": 10
+      }
+    ],
+    "49": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 72
+      },
+      {
+        "key": "Silver",
+        "weight": 85
+      },
+      {
+        "key": "Gold",
+        "weight": 58
+      },
+      {
+        "key": "Platinum",
+        "weight": 47
+      },
+      {
+        "key": "Sapphire",
+        "weight": 32
+      },
+      {
+        "key": "Ruby",
+        "weight": 33
+      },
+      {
+        "key": "Emerald",
+        "weight": 25
+      },
+      {
+        "key": "Mythril",
+        "weight": 17
+      },
+      {
+        "key": "Diamond",
+        "weight": 10
+      }
+    ],
+    "50": [
+      {
+        "key": "Stone",
+        "weight": 40
+      },
+      {
+        "key": "Copper",
+        "weight": 36
+      },
+      {
+        "key": "Iron",
+        "weight": 73
+      },
+      {
+        "key": "Silver",
+        "weight": 87
+      },
+      {
+        "key": "Gold",
+        "weight": 59
+      },
+      {
+        "key": "Platinum",
+        "weight": 48
+      },
+      {
+        "key": "Sapphire",
+        "weight": 32
+      },
+      {
+        "key": "Ruby",
+        "weight": 33
+      },
+      {
+        "key": "Emerald",
+        "weight": 26
+      },
+      {
+        "key": "Mythril",
+        "weight": 17
+      },
+      {
+        "key": "Diamond",
+        "weight": 10
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a server-hosted ore probability table that defines weights per floor
- load and normalize the probability table at runtime so ore spawns follow the server data with luck adjustments and safe fallbacks
- delay dungeon start until the probability table finishes loading and guard ore spawning against missing weights

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbae7fda0c83329661914612a20c09