### PR TITLE
Prevent dungeon tab switch when starting a run

### DIFF
--- a/index.html
+++ b/index.html
@@ -994,7 +994,6 @@ section[id^="tab-"].active{ display:block; }
       state.grid = new Array(25).fill(null);
       for(const o of ORES){ state.loot[o.key]=0; }
       Object.keys(state.skillCooldowns).forEach(k=> delete state.skillCooldowns[k]);
-      activateTab('dungeon');
       restartSpawnTimer();
       state.runStartTs = performance.now();
       startTick();


### PR DESCRIPTION
## Summary
- keep the current tab active when starting a dungeon run by removing the forced dungeon activation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84675fbc88332abdb6b8052e51585