### PR TITLE
Enable pet critical hits and improve damage legibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
     .ore .name{display:none}
     .hp{position:absolute;top:6px;left:6px;right:6px;height:8px;background:rgba(0,0,0,.35);border-radius:999px;border:1px solid rgba(255,255,255,.08);overflow:hidden}
     .hp>div{height:100%;background:linear-gradient(90deg,#34d399,#f59e0b);width:100%}
-    .dmg{position:absolute;pointer-events:none;font-weight:900;animation:float .6s ease-out forwards;white-space:nowrap}
+    .dmg{position:absolute;pointer-events:none;font-weight:900;animation:float .6s ease-out forwards;white-space:nowrap;color:#fdf7d8;-webkit-text-stroke:1.2px rgba(10,14,30,0.85);text-shadow:0 0 6px rgba(10,14,30,0.9),0 0 18px rgba(10,14,30,0.75);letter-spacing:0.5px}
+    .dmg.crit{color:#ffd1dc;-webkit-text-stroke:1.2px rgba(64,0,32,0.9);text-shadow:0 0 10px rgba(255,82,115,0.75),0 0 20px rgba(10,14,30,0.8)}
     @keyframes float{to{transform:translateY(-24px);opacity:0}}
 
     .pet{position:absolute;width:16px;height:16px;border-radius:50%;background:#22d3ee;border:2px solid #0e7490;box-shadow:0 0 10px rgba(34,211,238,.6)}
@@ -1121,14 +1122,15 @@ section[id^="tab-"].active{ display:block; }
       if(!state.inRun) return; const ore = state.grid[idx]; if(!ore) return;
       const atk = calcAtk();
       let dmg = Math.round(atk * (state.skillAtkBuffUntil>performance.now()?2:1));
-      const crit = (Math.random() < state.player.critChance && source==='tap');
+      const canCrit = (source === 'tap' || source === 'pet');
+      const crit = canCrit && Math.random() < state.player.critChance;
       if(crit) dmg = Math.floor(dmg * state.player.critMult);
       ore.hp -= dmg;
       const alive = ore.hp > 0;
       if(!alive){ onOreBroken(idx, ore); renderTop(); }
       renderGrid();
       const cell = state.grid[idx]?.el;
-      if(alive && cell){ const dm = document.createElement('div'); dm.className='dmg'; dm.textContent = (crit?'CRIT ':'') + '-' + dmg; dm.style.left='50%'; dm.style.top='38%'; dm.style.transform='translateX(-50%)'; cell.appendChild(dm); setTimeout(()=>dm.remove(), 520); }
+      if(alive && cell){ const dm = document.createElement('div'); dm.classList.add('dmg'); if(crit) dm.classList.add('crit'); dm.textContent = (crit?'CRIT ':'') + '-' + dmg; dm.style.left='50%'; dm.style.top='38%'; dm.style.transform='translateX(-50%)'; cell.appendChild(dm); setTimeout(()=>dm.remove(), 520); }
       (crit?SFX.crit:SFX.hit)();
     }
 


### PR DESCRIPTION
## Summary
- allow pet attacks to use the same critical-hit chance as manual taps
- add crit-specific styling and stronger outlines to floating damage numbers for better visibility

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d87ef1ff688332ac18fba86d3fd5aa