### PR TITLE
Adjust berserk active cost and ease upgrade scaling

### DIFF
--- a/data/skills.js
+++ b/data/skills.js
@@ -1,6 +1,6 @@
 // Active and passive skill definitions
 window.ACTIVE_SKILL_DATA = [
-  { key:'berserk',  name:'광폭화',   desc:'5초간 공격력 x2',         ae:150, cd:20 },
+  { key:'berserk',  name:'광폭화',   desc:'5초간 공격력 x2',         ae:50,  cd:20 },
   { key:'timewarp', name:'타임워프', desc:'시간 +3초(최대 20초)',    ae:120, cd:25 },
   { key:'meteor',   name:'운석 낙하', desc:'모든 광석에 큰 피해',    ae:200, cd:30 },
   { key:'haste',    name:'가속',     desc:'5초간 생성 속도 2배',     ae:140, cd:25 },

--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -1,9 +1,9 @@
 // Upgrade metadata and defaults
 window.UPGRADE_DEFAULTS = {
-  atk:   { level: 1, baseCost: 90,  scale: 1.35 },
-  crit:  { level: 0, baseCost: 150, scale: 1.7  },
-  spawn: { level: 0, baseCost: 240, scale: 1.8  },
-  pet:   { level: 0, baseCost: 450, scale: 2.0  },
+  atk:   { level: 1, baseCost: 90,  scale: 1.28 },
+  crit:  { level: 0, baseCost: 150, scale: 1.55 },
+  spawn: { level: 0, baseCost: 240, scale: 1.65 },
+  pet:   { level: 0, baseCost: 450, scale: 1.85 },
 };
 
 window.UPGRADE_INFO = [


### PR DESCRIPTION
## Summary
- lower the berserk active ability's base cost to make it more accessible
- reduce upgrade scaling factors to slow cost growth across upgrade types

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8826ab1808332b921e98db2354a9d