### PR TITLE
Use level-based upgrade costs and derived crit chance

### DIFF
--- a/data/skills.js
+++ b/data/skills.js
@@ -25,7 +25,8 @@ window.PASSIVE_SKILL_DATA = [
     ae:150,
     once:true,
     apply: ({ state }) => {
-      state.player.critChance = Math.min(0.5, state.player.critChance + 0.03);
+      const base = (typeof state.player.critChanceBase === 'number') ? state.player.critChanceBase : (state.player.critChance || 0.10);
+      state.player.critChanceBase = Math.min(0.5, base + 0.03);
     },
   },
   {

--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -1,17 +1,51 @@
 // Upgrade metadata and defaults
-window.UPGRADE_DEFAULTS = {
-  atk:   { level: 1, baseCost: 90,  scale: 1.28 },
-  crit:  { level: 0, baseCost: 150, scale: 1.55 },
-  spawn: { level: 0, baseCost: 240, scale: 1.65 },
-  pet:   { level: 0, baseCost: 450, scale: 1.85 },
+const UPGRADE_CONFIG = {
+  atk: {
+    defaultLevel: 1,
+    baseCost: 90,
+    costScale: 0.45,
+  },
+  crit: {
+    defaultLevel: 0,
+    baseCost: 150,
+    costScale: 0.5,
+    effectPerLevel: 0.02,
+  },
+  spawn: {
+    defaultLevel: 0,
+    baseCost: 240,
+    costScale: 0.55,
+  },
+  pet: {
+    defaultLevel: 0,
+    baseCost: 450,
+    costScale: 0.6,
+  },
 };
+
+window.UPGRADE_CONFIG = UPGRADE_CONFIG;
+
+window.UPGRADE_DEFAULTS = Object.fromEntries(
+  Object.entries(UPGRADE_CONFIG).map(([key, cfg]) => [key, { level: cfg.defaultLevel || 0 }])
+);
+
+function upgradeCostLinear(state, key) {
+  const cfg = UPGRADE_CONFIG[key];
+  if (!cfg) return 0;
+  const entry = state.upgrades[key] || {};
+  const currentLevel = typeof entry.level === 'number' ? entry.level : (cfg.defaultLevel || 0);
+  const baseLevel = cfg.defaultLevel || 0;
+  const steps = Math.max(0, currentLevel - baseLevel);
+  const scale = typeof cfg.costScale === 'number' ? cfg.costScale : 0;
+  return Math.floor(cfg.baseCost * (1 + steps * scale));
+}
 
 window.UPGRADE_INFO = [
   {
     key: 'atk',
     title: '🗡️ 공격력',
     getDescription: (state) => `현재: ${state.player.atk} (레벨 ${state.upgrades.atk.level})`,
-    getCost: (state) => Math.floor(state.upgrades.atk.baseCost * Math.pow(state.upgrades.atk.scale, state.upgrades.atk.level - 1)),
+    getCost: (state) => upgradeCostLinear(state, 'atk'),
     canBuy: () => true,
     onBuy: ({ state }) => {
       state.upgrades.atk.level++;
@@ -21,18 +55,17 @@ window.UPGRADE_INFO = [
     key: 'crit',
     title: '🎯 치명타 확률',
     getDescription: (state) => `현재: ${(state.player.critChance * 100).toFixed(1)}%`,
-    getCost: (state) => Math.floor(state.upgrades.crit.baseCost * Math.pow(state.upgrades.crit.scale, state.upgrades.crit.level)),
+    getCost: (state) => upgradeCostLinear(state, 'crit'),
     canBuy: (state) => (state.player.critChance >= 0.5 ? '최대 50%' : true),
     onBuy: ({ state }) => {
       state.upgrades.crit.level++;
-      state.player.critChance = Math.min(0.5, state.player.critChance + 0.02);
     },
   },
   {
     key: 'spawn',
     title: '⚙️ 생성 속도',
     getDescription: (state) => `레벨: ${state.upgrades.spawn.level}`,
-    getCost: (state) => Math.floor(state.upgrades.spawn.baseCost * Math.pow(state.upgrades.spawn.scale, state.upgrades.spawn.level)),
+    getCost: (state) => upgradeCostLinear(state, 'spawn'),
     canBuy: () => true,
     onBuy: ({ state, restartSpawnTimer }) => {
       state.upgrades.spawn.level++;
@@ -43,7 +76,7 @@ window.UPGRADE_INFO = [
     key: 'pet',
     title: '🤖 자동채굴 펫',
     getDescription: (state) => `보유: ${(state.upgrades.pet.level + (state.passive?.petPlus || 0) + (state.aether?.petPlus || 0))}마리`,
-    getCost: (state) => Math.floor(state.upgrades.pet.baseCost * Math.pow(state.upgrades.pet.scale, state.upgrades.pet.level)),
+    getCost: (state) => upgradeCostLinear(state, 'pet'),
     canBuy: () => true,
     onBuy: ({ state, spawnPets }) => {
       state.upgrades.pet.level++;

--- a/index.html
+++ b/index.html
@@ -309,6 +309,7 @@ section[id^="tab-"].active{ display:block; }
     const REBIRTH_PERKS = window.REBIRTH_PERK_DATA;
     const UPGRADE_INFO = window.UPGRADE_INFO;
     const UPGRADE_DEFAULTS = window.UPGRADE_DEFAULTS;
+    const UPGRADE_CONFIG = window.UPGRADE_CONFIG;
     const VERSION = 'miner_v2.6.1';
     // 고정 세이브키 + 구버전 마이그레이션
     const SAVE_KEY = 'miner_save_v1';
@@ -420,7 +421,7 @@ section[id^="tab-"].active{ display:block; }
 
     // ---------- Game State ----------
     const state = {
-      player: { atkBase: 10, atk: 10, critChance: 0.10, critMult: 2.0, gold: 0, ether: 0 },
+      player: { atkBase: 10, atk: 10, critChanceBase: 0.10, critChance: 0.10, critMult: 2.0, gold: 0, ether: 0 },
       upgrades: (()=>{
         const defaults = {};
         for(const [key, def] of Object.entries(UPGRADE_DEFAULTS||{})){
@@ -463,9 +464,10 @@ section[id^="tab-"].active{ display:block; }
     // ---------- Save/Load (stable key + migration) ----------
     function save(){
       const { atk, ...player } = state.player;
+      const { critChance, ...restPlayer } = player;
       const payload = {
         __version: VERSION,
-        player,
+        player: restPlayer,
         upgrades:state.upgrades, floor:state.floor, highestFloor:state.highestFloor,
         inventory:state.inventory, skillsOwnedActive:state.skillsOwnedActive, skillsOwnedPassive:state.skillsOwnedPassive,
         skillSlots:state.skillSlots, passive:state.passive, aether:state.aether, settings:state.settings
@@ -485,7 +487,16 @@ section[id^="tab-"].active{ display:block; }
         const s = JSON.parse(raw);
         Object.assign(state.player,s.player||{});
         delete state.player.atk;
-        Object.assign(state.upgrades,s.upgrades||{});
+        const savedUpgrades = s.upgrades || {};
+        if(savedUpgrades.oreMul && typeof savedUpgrades.oreMul === 'object'){
+          state.upgrades.oreMul = { ...state.upgrades.oreMul, ...savedUpgrades.oreMul };
+        }
+        for(const [key, def] of Object.entries(UPGRADE_DEFAULTS || {})){
+          const saved = savedUpgrades[key];
+          const lvl = typeof saved === 'number' ? saved
+            : (saved && typeof saved.level === 'number' ? saved.level : def.level || 0);
+          state.upgrades[key] = { level: Math.max(0, lvl) };
+        }
         state.floor=s.floor||1; state.highestFloor=s.highestFloor||1;
         state.inventory=s.inventory||state.inventory;
         state.skillsOwnedActive=s.skillsOwnedActive||{};
@@ -496,6 +507,15 @@ section[id^="tab-"].active{ display:block; }
         state.settings = s.settings || state.settings;
         if(typeof state.player.atkBase === 'undefined'){
           state.player.atkBase = (typeof s.player?.atk === 'number') ? s.player.atk : 10;
+        }
+        if(typeof state.player.critChanceBase !== 'number'){
+          const savedCrit = typeof s.player?.critChance === 'number' ? s.player.critChance : state.player.critChance;
+          const critCfg = UPGRADE_CONFIG?.crit;
+          const perLevel = critCfg?.effectPerLevel || 0;
+          const critLvl = state.upgrades?.crit?.level || 0;
+          const estimatedBase = typeof savedCrit === 'number' ? savedCrit - (perLevel * critLvl) : undefined;
+          const base = (typeof estimatedBase === 'number' && !Number.isNaN(estimatedBase)) ? estimatedBase : 0.10;
+          state.player.critChanceBase = Math.min(0.5, Math.max(0.01, +base.toFixed(4)));
         }
       }catch(e){ console.warn('load failed', e); }
     }
@@ -803,6 +823,16 @@ section[id^="tab-"].active{ display:block; }
       return upgMul * passiveMul;
     }
 
+    function calcCritChance(){
+      const cfg = UPGRADE_CONFIG?.crit;
+      const base = (typeof state.player.critChanceBase === 'number') ? state.player.critChanceBase : 0.10;
+      const lvl = state.upgrades.crit?.level || 0;
+      const perLevel = cfg?.effectPerLevel || 0.02;
+      const total = Math.min(0.5, Math.max(0, +(base + (perLevel * lvl)).toFixed(4)));
+      state.player.critChance = total;
+      return total;
+    }
+
     function calcAtk() {
       const L = state.upgrades.atk?.level || 1;
       const base = state.player.atkBase || 10;
@@ -812,6 +842,7 @@ section[id^="tab-"].active{ display:block; }
       const bonus = Math.pow(1 + ATK_MILE, Math.floor(Math.max(0, L - 1) / 10));
       const atk = Math.max(1, Math.ceil(base * per * bonus));
       state.player.atk = atk;
+      calcCritChance();
       return atk;
     }
 


### PR DESCRIPTION
## Summary
- replace exponential upgrade prices with configurable level-based scaling so balance tweaks apply to existing saves
- derive critical chance from a stored base value plus upgrade level, including save migration logic
- update the passive crit skill to add to the new base stat instead of the derived value

## Testing
- not run (web app changes)


------
https://chatgpt.com/codex/tasks/task_e_68d888e574008332b368504ef09a75b8