### PR TITLE
Enable continuous pet attack cycles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1429,13 +1429,13 @@ section[id^="tab-"].active{ display:block; }
           vx:0,
           vy:0,
           targetIdx:-1,
-          cd:0,
           swinging:false,
           swingTime:0,
           swingBaseAngle:0,
           swingDir:1,
           swingArc:PET.swingArc,
           swingRadius:PET.swingRadius,
+          swingDuration:PET.atkInterval,
           wanderAngle: Math.random()*Math.PI*2,
           wanderTimer: Math.random()*0.5,
           wanderSpeed: 30 + Math.random()*20,
@@ -1490,19 +1490,30 @@ section[id^="tab-"].active{ display:block; }
       }
       return findNearestOreFromList(p.x, p.y, oreIndices);
     }
-    function startPetSwing(p, ore){
-      if(!ore) return;
-      const baseAngle = Math.random()*Math.PI*2;
+    function configurePetSwing(p, ore, reuseCycle=false){
+      if(!ore) return false;
+      const dx = ore.x - p.x;
+      const dy = ore.y - p.y;
+      const dist = Math.hypot(dx, dy) || 1;
+      const towardOre = Math.atan2(dy, dx);
+      let baseAngle;
+      if(reuseCycle && Number.isFinite(p.swingBaseAngle)){
+        baseAngle = p.swingBaseAngle + Math.PI + (Math.random()*0.3 - 0.15);
+      }else{
+        baseAngle = towardOre + Math.PI/2 + (Math.random()*0.6 - 0.3);
+      }
       const axisX = Math.cos(baseAngle);
       const axisY = Math.sin(baseAngle);
       const perpX = -axisY;
       const perpY = axisX;
+      const swingDir = reuseCycle && p.swingDir ? -p.swingDir : (Math.random() < 0.5 ? -1 : 1);
+      const reach = Math.max(ORE_RADIUS + 6, dist);
+      const amplitude = Math.min(reach + 12, PET.swingRadius * (0.95 + Math.random()*0.4));
+      const inertia = amplitude * (0.52 + Math.random()*0.38);
       p.swinging = true;
       p.swingTime = 0;
-      p.swingDir = Math.random() < 0.5 ? -1 : 1;
-      const reach = Math.hypot(p.x - ore.x, p.y - ore.y) || PET.swingRadius;
-      const amplitude = Math.max(ORE_RADIUS + 6, Math.min(reach, PET.swingRadius * (0.9 + Math.random()*0.6)));
-      const inertia = amplitude * (0.45 + Math.random()*0.55);
+      p.swingDir = swingDir;
+      p.swingBaseAngle = baseAngle;
       p.swingAxisX = axisX;
       p.swingAxisY = axisY;
       p.swingPerpX = perpX;
@@ -1511,11 +1522,16 @@ section[id^="tab-"].active{ display:block; }
       p.swingOriginY = ore.y;
       p.swingAmplitude = amplitude;
       p.swingInertia = inertia;
-      p.swingDriftAngle = Math.random()*Math.PI*2;
-      p.swingDriftStrength = 6 + Math.random()*12;
+      p.swingDuration = PET.atkInterval;
+      p.swingDriftAngle = towardOre + (Math.random()*0.6 - 0.3);
+      p.swingDriftStrength = (6 + Math.random()*12) * (amplitude / PET.swingRadius);
       p.swingNoiseSeed = Math.random()*Math.PI*2;
       p.swingStartOffsetX = p.x - ore.x;
       p.swingStartOffsetY = p.y - ore.y;
+      return true;
+    }
+    function startPetSwing(p, ore){
+      if(!configurePetSwing(p, ore, false)) return;
       p.vx *= 0.4;
       p.vy *= 0.4;
     }
@@ -1524,7 +1540,7 @@ section[id^="tab-"].active{ display:block; }
       const prevX = p.x;
       const prevY = p.y;
       p.swingTime += dt;
-      const duration = PET.swingDuration * 1.35;
+      const duration = Math.max(0.12, p.swingDuration || PET.atkInterval);
       const tRaw = Math.min(1, p.swingTime / duration);
       const axisX = p.swingAxisX || 1;
       const axisY = p.swingAxisY || 0;
@@ -1550,12 +1566,18 @@ section[id^="tab-"].active{ display:block; }
       p.x = originX + startOffsetX + offsetX;
       p.y = originY + startOffsetY + offsetY;
       if(p.swingTime >= duration){
-        p.swinging = false;
-        p.cd = PET.atkInterval;
         const dtSafe = Math.max(dt, 0.016);
         p.vx = (p.x - prevX) / dtSafe * 0.6;
         p.vy = (p.y - prevY) / dtSafe * 0.6;
         hit(p.targetIdx,'pet');
+        const nextOre = (p.targetIdx>=0) ? state.grid[p.targetIdx] : null;
+        if(nextOre){
+          configurePetSwing(p, nextOre, true);
+        } else {
+          p.swinging = false;
+          p.swingTime = 0;
+          p.targetIdx = -1;
+        }
         return true;
       }
       return false;
@@ -1664,9 +1686,8 @@ section[id^="tab-"].active{ display:block; }
           p.targetIdx = -1;
           continue;
         }
-        p.cd = Math.max(0, p.cd - dt);
         const dist = Math.hypot(ore.x - p.x, ore.y - p.y);
-        if(p.cd<=0 && dist<=PET.swingRadius){
+        if(dist<=PET.swingRadius){
           startPetSwing(p, ore);
         }
       }


### PR DESCRIPTION
## Summary
- compute pet swing paths from the active target so they can loop attacks at the base interval
- remove the separate cooldown so pets immediately chain swings without idle downtime

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8a4fcc5408332a974db4618fa9e64