### PR TITLE
Adjust ether spawn timing and show upgrade counts

### DIFF
--- a/data/aether.js
+++ b/data/aether.js
@@ -27,7 +27,7 @@ window.REBIRTH_PERK_DATA = [
   {
     key: 'etherHaste',
     name: '에테르 공명',
-    desc: '에테르 등장 -1초(최소 5초)',
+    desc: '에테르 등장 -0.5초',
     base: 36,
     scale: 1.6,
     max: 10,

--- a/data/skills.js
+++ b/data/skills.js
@@ -11,9 +11,10 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'power',
     name:'강화 채굴',
-    desc:'공격력 +1(기초)',
+    desc:'기초공격력 +1',
     ae:120,
     once:true,
+    maxLevel:1,
     apply: ({ state }) => {
       state.player.atkBase = (state.player.atkBase || 10) + 1;
     },
@@ -21,9 +22,10 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'sharp',
     name:'예리함',
-    desc:'치명타 확률 +3% (최대 50%)',
+    desc:'치명타 확률 +3%',
     ae:150,
     once:true,
+    maxLevel:1,
     apply: ({ state }) => {
       const base = (typeof state.player.critChanceBase === 'number') ? state.player.critChanceBase : (state.player.critChance || 0.10);
       state.player.critChanceBase = Math.min(0.5, base + 0.03);
@@ -32,9 +34,10 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'merchant',
     name:'상인 감각',
-    desc:'판매가 +10%',
+    desc:'판매 보너스 +10%',
     ae:180,
     once:false,
+    maxLevel:20,
     apply: ({ state }) => {
       state.passive.sellBonus = (state.passive.sellBonus || 0) + 0.10;
     },
@@ -42,9 +45,10 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'petmaster',
     name:'펫 조련',
-    desc:'펫 +1',
+    desc:'펫 +1마리',
     ae:200,
     once:false,
+    maxLevel:20,
     apply: ({ state, spawnPets }) => {
       state.passive.petPlus = (state.passive.petPlus || 0) + 1;
       if(state.inRun && typeof spawnPets === 'function') spawnPets();

--- a/data/skills.js
+++ b/data/skills.js
@@ -11,10 +11,9 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'power',
     name:'강화 채굴',
-    desc:'기초공격력 +1',
     ae:120,
     once:true,
-    maxLevel:1,
+    maxLevel:50,
     apply: ({ state }) => {
       state.player.atkBase = (state.player.atkBase || 10) + 1;
     },
@@ -22,10 +21,9 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'sharp',
     name:'예리함',
-    desc:'치명타 확률 +3%',
     ae:150,
     once:true,
-    maxLevel:1,
+    maxLevel:30,
     apply: ({ state }) => {
       const base = (typeof state.player.critChanceBase === 'number') ? state.player.critChanceBase : (state.player.critChance || 0.10);
       state.player.critChanceBase = Math.min(0.5, base + 0.03);
@@ -34,7 +32,6 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'merchant',
     name:'상인 감각',
-    desc:'판매 보너스 +10%',
     ae:180,
     once:false,
     maxLevel:20,
@@ -45,7 +42,6 @@ window.PASSIVE_SKILL_DATA = [
   {
     key:'petmaster',
     name:'펫 조련',
-    desc:'펫 +1마리',
     ae:200,
     once:false,
     maxLevel:20,

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ section[id^="tab-"].active{ display:block; }
         </div>
         <div class="ae-card">
           <h4>환생 준비</h4>
-          <div class="ae-meta">지하 20층 이상에서 환생 가능. 아래 보너스를 이번 환생에 함께 구매할 수 있습니다.</div>
+          <div class="ae-meta">지하 20층 이상에서 환생 가능. 아래 보너스를 이번 환생에 함께 구매할 수 있습니다. 에테르로 구매한 스킬들은 환생해도 초기화되지 않습니다.</div>
           <div id="rebirthPerks" class="aether-grid" style="margin-top:8px"></div>
           <div class="row" style="justify-content:space-between;margin-top:8px">
             <div class="mono">총 비용: <b id="rebirthTotal">0</b> 에테르</div>
@@ -1136,9 +1136,17 @@ section[id^="tab-"].active{ display:block; }
         const cost = perkCost(p);
         const checked = !!rebirthPick[p.key];
         const row = document.createElement('div'); row.className='skill-card';
-        row.innerHTML = `<div class="row" style="justify-content:space-between"><b>${p.name}</b><span class="mono">${p.desc}</span></div>
-                         <div class="row" style="justify-content:space-between;margin-top:6px">
-                           <div class="mono">레벨 ${lvl}/${p.max} · 비용 ${cost} 에테르</div>
+        const header = `<div class="row" style="justify-content:space-between"><b>${p.name}</b><span class="mono">Lv ${lvl}/${p.max}</span></div>`;
+        const desc = `<div class="mono" style="opacity:.8;margin:4px 0 6px 0">${p.desc}</div>`;
+        let extra = '';
+        if(p.key === 'etherHaste'){
+          const delay = Math.max(0, 15 - (lvl * 0.5));
+          const formatted = Number.isInteger(delay) ? delay.toFixed(0) : delay.toFixed(1);
+          extra = `<div class="mono" style="margin:0 0 6px 0">현재 등장: ${formatted}초</div>`;
+        }
+        row.innerHTML = header + desc + extra +
+                         `<div class="row" style="justify-content:space-between;margin-top:6px">
+                           <div class="mono">비용 ${cost} 에테르</div>
                            <label class="row" style="gap:6px;align-items:center">
                              <input type="checkbox" ${checked?'checked':''} ${maxed?'disabled':''} data-perk="${p.key}">
                              <span>${maxed?'최대':''}선택</span>
@@ -1190,9 +1198,16 @@ section[id^="tab-"].active{ display:block; }
 
       const shopP = $('#skillShopPassive'); shopP.innerHTML='';
       for(const sk of PASSIVE_SKILLS){
-        const owned = !!state.skillsOwnedPassive[sk.key];
+        const ownedCount = state.skillsOwnedPassive[sk.key] || 0;
+        const owned = ownedCount > 0;
+        const currentText = sk.once
+          ? `현재: ${Math.min(1, ownedCount)}/1`
+          : `현재: ${ownedCount}회`;
         const card = document.createElement('div'); card.className = 'skill-card';
-        card.innerHTML = `<div class="row" style="justify-content:space-between"><b>${sk.name}</b><span class="mono">패시브</span></div><div class="mono" style="opacity:.8;margin:4px 0 8px 0">${sk.desc}</div><div class="row" style="justify-content:space-between"><div>가격: <b class="price">${sk.ae}</b> 에테르</div><button class="btn" ${owned && sk.once?'disabled':''}>${owned?(sk.once?'보유중':'추가 구매'):'구매'}</button></div>`;
+        card.innerHTML = `<div class="row" style="justify-content:space-between"><b>${sk.name}</b><span class="mono">패시브</span></div>`+
+                         `<div class="mono" style="opacity:.8;margin:4px 0 4px 0">${sk.desc}</div>`+
+                         `<div class="mono" style="margin:0 0 8px 0">${currentText}</div>`+
+                         `<div class="row" style="justify-content:space-between"><div>가격: <b class="price">${sk.ae}</b> 에테르</div><button class="btn" ${owned && sk.once?'disabled':''}>${owned?(sk.once?'보유중':'추가 구매'):'구매'}</button></div>`;
         const buyBtn = card.querySelector('.btn');
         if(buyBtn){
           buyBtn.addEventListener('click', ()=>{
@@ -1369,8 +1384,8 @@ section[id^="tab-"].active{ display:block; }
         if(!state.inRun) return;
         const now = performance.now();
         const elapsed = (now - state.runStartTs)/1000;
-        let etherDelay = 10 + Math.min(state.floor*0.5, 20) - (state.aether?.etherHaste||0);
-        etherDelay = Math.max(5, etherDelay);
+        const etherHasteLevel = state.aether?.etherHaste || 0;
+        const etherDelay = 15 - (etherHasteLevel * 0.5);
         if(!state.etherSpawned && elapsed >= etherDelay){ spawnEther(); }
         state.timeLeft = Math.max(0, +(state.timeLeft - 0.1).toFixed(1));
         for(const k of Object.keys(state.skillCooldowns)){ state.skillCooldowns[k] = Math.max(0, state.skillCooldowns[k]-0.1); }

--- a/index.html
+++ b/index.html
@@ -310,7 +310,16 @@ section[id^="tab-"].active{ display:block; }
     const PASSIVE_SKILLS = window.PASSIVE_SKILL_DATA;
     const PASSIVE_DISPLAY_INFO = {
       power: { label:'기초공격력', unit:'', perLevel:1 },
-      sharp: { label:'치명타 확률', unit:'%', perLevel:3 },
+      sharp: {
+        label:'치명타 확률',
+        unit:'%',
+        calcTotal: (level) => Math.min(40, level * 3),
+        calcDelta: (level) => {
+          const current = Math.min(40, level * 3);
+          const next = Math.min(40, (level + 1) * 3);
+          return Math.max(0, next - current);
+        },
+      },
       merchant: { label:'판매 보너스', unit:'%', perLevel:10 },
       petmaster: { label:'펫', unit:'마리', perLevel:1 },
     };
@@ -955,7 +964,13 @@ section[id^="tab-"].active{ display:block; }
 
     function calcAtk() {
       const L = state.upgrades.atk?.level || 1;
-      const base = state.player.atkBase || 10;
+      const powerPassive = PASSIVE_SKILLS.find((sk) => sk.key === 'power');
+      const maxPowerLevel = powerPassive ? passiveMaxLevel(powerPassive) : 0;
+      const ownedPower = Math.min(maxPowerLevel, state.skillsOwnedPassive?.power || 0);
+      const baseFloor = 10 + ownedPower;
+      const storedBase = (typeof state.player.atkBase === 'number') ? state.player.atkBase : 10;
+      const base = Math.max(storedBase, baseFloor);
+      state.player.atkBase = base;
       const ATK_PER_LVL = 0.12;
       const ATK_MILE    = 0.35;
       const per   = Math.pow(1 + ATK_PER_LVL, Math.max(0, L - 1));

--- a/index.html
+++ b/index.html
@@ -321,7 +321,15 @@ section[id^="tab-"].active{ display:block; }
         },
       },
       merchant: { label:'판매 보너스', unit:'%', perLevel:10 },
-      petmaster: { label:'펫', unit:'마리', perLevel:1 },
+      petmaster: {
+        label:'펫',
+        unit:'마리',
+        perLevel:1,
+        formatDelta: (value) => {
+          const num = Number.isFinite(value) ? value : 0;
+          return Number.isInteger(num) ? num.toString() : num.toFixed(2).replace(/\.0+$/,'').replace(/0+$/,'');
+        },
+      },
     };
     const REBIRTH_PERKS = window.REBIRTH_PERK_DATA;
     const UPGRADE_INFO = window.UPGRADE_INFO;
@@ -1231,7 +1239,7 @@ section[id^="tab-"].active{ display:block; }
       if(isMaxed){ return baseText; }
       const deltaValue = cfg.calcDelta ? cfg.calcDelta(safeLevel) : (cfg.perLevel ?? 0);
       if(!deltaValue){ return baseText; }
-      const deltaText = formatPassiveValue(deltaValue, cfg);
+      const deltaText = cfg.formatDelta ? cfg.formatDelta(deltaValue, cfg) : formatPassiveValue(deltaValue, cfg);
       return `${baseText} (+${deltaText})`;
     }
 

--- a/index.html
+++ b/index.html
@@ -308,6 +308,12 @@ section[id^="tab-"].active{ display:block; }
     const ACTIVE_SKILLS = window.ACTIVE_SKILL_DATA;
     const BERSERK_SKILL = ACTIVE_SKILLS.find(s=>s.key==='berserk');
     const PASSIVE_SKILLS = window.PASSIVE_SKILL_DATA;
+    const PASSIVE_DISPLAY_INFO = {
+      power: { label:'기초공격력', unit:'', perLevel:1 },
+      sharp: { label:'치명타 확률', unit:'%', perLevel:3 },
+      merchant: { label:'판매 보너스', unit:'%', perLevel:10 },
+      petmaster: { label:'펫', unit:'마리', perLevel:1 },
+    };
     const REBIRTH_PERKS = window.REBIRTH_PERK_DATA;
     const UPGRADE_INFO = window.UPGRADE_INFO;
     const UPGRADE_DEFAULTS = window.UPGRADE_DEFAULTS;
@@ -1180,6 +1186,40 @@ section[id^="tab-"].active{ display:block; }
       return changed;
     }
 
+    function passiveMaxLevel(sk){
+      if(typeof sk.maxLevel === 'number' && sk.maxLevel > 0){ return sk.maxLevel; }
+      if(sk.once){ return 1; }
+      return 20;
+    }
+
+    function formatPassiveValue(value, cfg){
+      const num = Number.isFinite(value) ? value : 0;
+      let str;
+      if(cfg && typeof cfg.decimals === 'number'){
+        str = num.toFixed(cfg.decimals);
+      }else if(Number.isInteger(num)){
+        str = num.toString();
+      }else{
+        str = num.toFixed(2).replace(/\.0+$/,'').replace(/0+$/,'');
+      }
+      if(cfg?.unit === '%'){ return `${str}%`; }
+      if(cfg?.unit){ return `${str}${cfg.unit}`; }
+      return str;
+    }
+
+    function buildPassiveStatLine(sk, level, isMaxed){
+      const cfg = PASSIVE_DISPLAY_INFO[sk.key];
+      if(!cfg){ return ''; }
+      const safeLevel = Math.max(0, level);
+      const totalValue = cfg.calcTotal ? cfg.calcTotal(safeLevel) : safeLevel * (cfg.perLevel ?? 0);
+      const baseText = `${cfg.label} ${formatPassiveValue(totalValue, cfg)}`;
+      if(isMaxed){ return baseText; }
+      const deltaValue = cfg.calcDelta ? cfg.calcDelta(safeLevel) : (cfg.perLevel ?? 0);
+      if(!deltaValue){ return baseText; }
+      const deltaText = formatPassiveValue(deltaValue, cfg);
+      return `${baseText} (+${deltaText})`;
+    }
+
     function renderSkills(){
       ensurePassiveDefaults();
       const slotsUpdated = syncSkillSlotsWithOwned();
@@ -1199,23 +1239,33 @@ section[id^="tab-"].active{ display:block; }
       const shopP = $('#skillShopPassive'); shopP.innerHTML='';
       for(const sk of PASSIVE_SKILLS){
         const ownedCount = state.skillsOwnedPassive[sk.key] || 0;
+        const maxLevel = passiveMaxLevel(sk);
+        const displayLevel = Math.min(ownedCount, maxLevel);
+        const isMaxed = ownedCount >= maxLevel;
         const owned = ownedCount > 0;
-        const currentText = sk.once
-          ? `현재: ${Math.min(1, ownedCount)}/1`
-          : `현재: ${ownedCount}회`;
+        const levelLabel = `Lv ${displayLevel}/${maxLevel}`;
+        const statLine = buildPassiveStatLine(sk, displayLevel, isMaxed);
         const card = document.createElement('div'); card.className = 'skill-card';
-        card.innerHTML = `<div class="row" style="justify-content:space-between"><b>${sk.name}</b><span class="mono">패시브</span></div>`+
-                         `<div class="mono" style="opacity:.8;margin:4px 0 4px 0">${sk.desc}</div>`+
-                         `<div class="mono" style="margin:0 0 8px 0">${currentText}</div>`+
-                         `<div class="row" style="justify-content:space-between"><div>가격: <b class="price">${sk.ae}</b> 에테르</div><button class="btn" ${owned && sk.once?'disabled':''}>${owned?(sk.once?'보유중':'추가 구매'):'구매'}</button></div>`;
+        const descBlock = sk.desc ? `<div class="mono" style="opacity:.8;margin:4px 0 ${statLine?4:8}px 0">${sk.desc}</div>` : '';
+        const statBlock = statLine ? `<div class="mono" style="margin:0 0 8px 0">${statLine}</div>` : '';
+        const buttonLabel = isMaxed
+          ? (sk.once ? '보유중' : '최대 레벨')
+          : (owned ? '추가 구매' : '구매');
+        const buttonDisabled = isMaxed;
+        const buttonRow = `<div class="row" style="justify-content:space-between${(!statLine && !sk.desc)?';margin-top:8px':''}"><div>가격: <b class="price">${sk.ae}</b> 에테르</div><button class="btn" ${buttonDisabled?'disabled':''}>${buttonLabel}</button></div>`;
+        card.innerHTML = `<div class="row" style="justify-content:space-between"><b>${sk.name}</b><span class="mono">${levelLabel}</span></div>`+
+                         descBlock +
+                         statBlock +
+                         buttonRow;
         const buyBtn = card.querySelector('.btn');
         if(buyBtn){
           buyBtn.addEventListener('click', ()=>{
+            if(ownedCount >= maxLevel){ toast('최대 레벨입니다.'); SFX.deny(); return; }
             if(!spendAe(sk.ae)) { SFX.deny(); return; }
-            if(sk.once && owned){ toast('이미 보유'); SFX.deny(); return; }
             if(!state.skillsOwnedPassive[sk.key]) state.skillsOwnedPassive[sk.key]=0;
-            state.skillsOwnedPassive[sk.key] += 1;
-            if(typeof sk.apply === 'function'){ sk.apply({ state, spawnPets }); }
+            const nextLevel = Math.min(maxLevel, state.skillsOwnedPassive[sk.key] + 1);
+            state.skillsOwnedPassive[sk.key] = nextLevel;
+            if(typeof sk.apply === 'function'){ sk.apply({ state, restartSpawnTimer, spawnPets }); }
             ensurePassiveDefaults();
             toast(`${sk.name} 적용!`); SFX.ui(); save(); renderSkills(); renderUpgrades(); renderTop();
           });


### PR DESCRIPTION
## Summary
- set the ether spawn delay to a flat 15 seconds and apply 0.5 second reductions per ether haste level
- surface current purchase counts in the passive skill shop and rebirth perk cards, including the new persistence note for rebirths
- refresh the ether haste description and in-game guidance to match the new behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8be80930c833290106cdc54a0ffb9