### PR TITLE
Add level labels and rebirth resets for gold upgrades

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -20,6 +20,7 @@ const UPGRADE_CONFIG = {
     defaultLevel: 0,
     baseCost: 450,
     costScale: 0.6,
+    maxLevel: 100,
   },
 };
 
@@ -44,7 +45,9 @@ window.UPGRADE_INFO = [
   {
     key: 'atk',
     title: '🗡️ 공격력',
-    getDescription: (state) => `현재: ${state.player.atk} (레벨 ${state.upgrades.atk.level})`,
+    getLevel: (state) => state.upgrades.atk.level,
+    getLevelLabel: (state) => `Lv ${state.upgrades.atk.level}`,
+    getDescription: (state) => `현재 공격력: ${state.player.atk}`,
     getCost: (state) => upgradeCostLinear(state, 'atk'),
     canBuy: () => true,
     onBuy: ({ state }) => {
@@ -54,9 +57,11 @@ window.UPGRADE_INFO = [
   {
     key: 'crit',
     title: '🎯 치명타 확률',
-    getDescription: (state) => `현재: ${(state.player.critChance * 100).toFixed(1)}%`,
+    getLevel: (state) => state.upgrades.crit.level,
+    getLevelLabel: (state) => `Lv ${state.upgrades.crit.level}`,
+    getDescription: (state) => `현재 치명타 확률: ${(state.player.critChance * 100).toFixed(1)}%`,
     getCost: (state) => upgradeCostLinear(state, 'crit'),
-    canBuy: (state) => (state.player.critChance >= 0.5 ? '최대 50%' : true),
+    canBuy: () => true,
     onBuy: ({ state }) => {
       state.upgrades.crit.level++;
     },
@@ -64,7 +69,15 @@ window.UPGRADE_INFO = [
   {
     key: 'spawn',
     title: '⚙️ 생성 속도',
-    getDescription: (state) => `레벨: ${state.upgrades.spawn.level}`,
+    getLevel: (state) => state.upgrades.spawn.level,
+    getLevelLabel: (state) => `Lv ${state.upgrades.spawn.level}`,
+    getDescription: (state) => {
+      const level = state.upgrades.spawn.level;
+      const baseMs = 2200;
+      let interval = baseMs * Math.pow(0.94, level);
+      if (interval < 600) interval = 600;
+      return `현재 생성 간격: ${(interval / 1000).toFixed(2)}초`;
+    },
     getCost: (state) => upgradeCostLinear(state, 'spawn'),
     canBuy: () => true,
     onBuy: ({ state, restartSpawnTimer }) => {
@@ -75,9 +88,22 @@ window.UPGRADE_INFO = [
   {
     key: 'pet',
     title: '🤖 자동채굴 펫',
+    getLevel: (state) => state.upgrades.pet.level,
+    getLevelLabel: (state) => {
+      const level = state.upgrades.pet.level;
+      const max = UPGRADE_CONFIG.pet.maxLevel || 0;
+      return max ? `Lv ${level}/${max}` : `Lv ${level}`;
+    },
     getDescription: (state) => `보유: ${(state.upgrades.pet.level + (state.passive?.petPlus || 0) + (state.aether?.petPlus || 0))}마리`,
     getCost: (state) => upgradeCostLinear(state, 'pet'),
-    canBuy: () => true,
+    canBuy: (state) => {
+      const max = UPGRADE_CONFIG.pet.maxLevel || Infinity;
+      const current = state.upgrades.pet.level || 0;
+      if (current >= max) {
+        return `최대 ${max}마리까지 구매 가능합니다.`;
+      }
+      return true;
+    },
     onBuy: ({ state, spawnPets }) => {
       state.upgrades.pet.level++;
       if (state.inRun) spawnPets();

--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@ section[id^="tab-"].active{ display:block; }
           const critLvl = state.upgrades?.crit?.level || 0;
           const estimatedBase = typeof savedCrit === 'number' ? savedCrit - (perLevel * critLvl) : undefined;
           const base = (typeof estimatedBase === 'number' && !Number.isNaN(estimatedBase)) ? estimatedBase : 0.10;
-          state.player.critChanceBase = Math.min(0.5, Math.max(0.01, +base.toFixed(4)));
+          state.player.critChanceBase = Math.max(0.01, +base.toFixed(4));
         }
       }catch(e){ console.warn('load failed', e); }
     }
@@ -965,7 +965,8 @@ section[id^="tab-"].active{ display:block; }
       const base = (typeof state.player.critChanceBase === 'number') ? state.player.critChanceBase : 0.10;
       const lvl = state.upgrades.crit?.level || 0;
       const perLevel = cfg?.effectPerLevel || 0.02;
-      const total = Math.min(0.5, Math.max(0, +(base + (perLevel * lvl)).toFixed(4)));
+      const totalRaw = base + (perLevel * lvl);
+      const total = Math.max(0, +totalRaw.toFixed(4));
       state.player.critChance = total;
       return total;
     }
@@ -1125,7 +1126,11 @@ section[id^="tab-"].active{ display:block; }
       for(const info of UPGRADE_INFO || []){
         const desc = typeof info.getDescription === 'function' ? info.getDescription(state) : '';
         const cost = typeof info.getCost === 'function' ? info.getCost(state) : 0;
-        cont.appendChild(upgradeCard(info.title, desc, cost, ()=>{
+        const baseLevel = typeof info.getLevel === 'function' ? info.getLevel(state) : null;
+        const levelLabel = typeof info.getLevelLabel === 'function'
+          ? info.getLevelLabel(state)
+          : (baseLevel !== null && baseLevel !== undefined ? `Lv ${baseLevel}` : '');
+        cont.appendChild(upgradeCard(info.title, levelLabel, desc, cost, ()=>{
           const check = typeof info.canBuy === 'function' ? info.canBuy(state) : true;
           if(check !== true){
             if(typeof check === 'string' && check){ toast(check); }
@@ -1143,7 +1148,23 @@ section[id^="tab-"].active{ display:block; }
         }));
       }
     }
-    function upgradeCard(title, desc, cost, onBuy){ const wrap=document.createElement('div'); wrap.className='inv-item'; wrap.innerHTML = `<h4 style="margin:0 0 4px 0">${title}</h4><div class="mono">${desc}</div><div class="row" style="margin-top:8px;justify-content:space-between"><div class="row"><span>가격:</span> <b class="price">${cost}</b></div><button class="btn">구매</button></div>`; wrap.querySelector('.btn').addEventListener('click', onBuy); return wrap; }
+    function upgradeCard(title, levelLabel, desc, cost, onBuy){
+      const wrap=document.createElement('div');
+      wrap.className='inv-item';
+      const headerRight = levelLabel ? `<span class="mono">${levelLabel}</span>` : '';
+      wrap.innerHTML = `
+        <div class="row" style="justify-content:space-between;align-items:center;margin:0 0 4px 0">
+          <h4 style="margin:0">${title}</h4>
+          ${headerRight}
+        </div>
+        <div class="mono">${desc}</div>
+        <div class="row" style="margin-top:8px;justify-content:space-between">
+          <div class="row"><span>가격:</span> <b class="price">${cost}</b></div>
+          <button class="btn">구매</button>
+        </div>`;
+      wrap.querySelector('.btn').addEventListener('click', onBuy);
+      return wrap;
+    }
     function spend(amount){ if(state.player.gold < amount){ toast('골드 부족'); return false; } state.player.gold -= amount; return true; }
     function spendAe(amount){ if(state.player.ether < amount){ toast('에테르 부족'); return false; } state.player.ether -= amount; return true; }
 
@@ -1505,6 +1526,40 @@ section[id^="tab-"].active{ display:block; }
       if(cleared && state.aether?.autoAdvanceOwned && state.aether.autoAdvanceEnabled){
         setTimeout(()=>{ startRun(); }, 250);
       }
+    }
+
+    function cancelRunWithoutRewards(){
+      if(!state.inRun) return;
+      for(const k in state.loot){ state.loot[k] = 0; }
+      state.inRun = false;
+      clearInterval(state.timers.spawn); state.timers.spawn = null;
+      clearInterval(state.timers.tick); state.timers.tick = null;
+      state.pets = [];
+      state.lastAnimTs = 0;
+      state.grid = new Array(25).fill(null);
+      state.timeLeft = 0;
+      renderSkillBar();
+      gridRectCache = null;
+      refresh();
+    }
+
+    function resetGoldProgression(){
+      const freshUpgrades = {};
+      for(const [key, def] of Object.entries(UPGRADE_DEFAULTS || {})){
+        const baseLevel = def && typeof def.level === 'number' ? def.level : 0;
+        freshUpgrades[key] = { level: baseLevel };
+      }
+      freshUpgrades.oreMul = {};
+      state.upgrades = freshUpgrades;
+      state.player.gold = 0;
+      for(const ore of ORES){
+        state.inventory[ore.key] = 0;
+        state.oreSales[ore.key] = 0;
+        state.loot[ore.key] = 0;
+        state.upgrades.oreMul[ore.key] = 0;
+      }
+      state.floor = 1;
+      state.highestFloor = 1;
     }
 
     function spawnOre(){
@@ -2054,10 +2109,14 @@ section[id^="tab-"].active{ display:block; }
       if(!confirm('선택한 보너스를 구매하고 환생하시겠습니까?')) return;
       state.player.ether -= total;
       for(const p of chosen){ if(typeof p.apply === 'function') p.apply({ state }); }
-      if(state.inRun) bankAndExit(false);
-      state.floor = 1; state.aether.rebirths = (state.aether.rebirths||0)+1;
+      if(state.inRun) cancelRunWithoutRewards();
+      resetGoldProgression();
+      state.aether.rebirths = (state.aether.rebirths||0)+1;
       for(const k in rebirthPick){ delete rebirthPick[k]; }
-      save(); renderAether(); renderTop(); toast('보너스 구매 및 환생 완료!');
+      save();
+      renderAether();
+      refresh();
+      toast('보너스 구매 및 환생 완료!');
     });
     document.addEventListener('change', (e)=>{
       const t = e.target;


### PR DESCRIPTION
## Summary
- show level badges on gold upgrades and adjust descriptions, including spawn speed details
- remove the gold crit cap, enforce a 100-pet purchase ceiling, and display pet level limits
- cancel active runs without rewards when rebirthing and reset gold-based progression to defaults

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8d0177ce4833299b68ba4f67e1d1d