### PR TITLE
Adjust spawn interval step and preview labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1521,10 +1521,12 @@ section[id^="tab-"].active{ display:block; }
     }
 
     function restartSpawnTimer(){
-      const baseMs=2200; const level=state.upgrades.spawn.level;
-      let interval= baseMs*Math.pow(0.94, level);
+      const level = state.upgrades.spawn.level;
+      const baseInterval = (typeof window.spawnIntervalForLevel === 'function')
+        ? window.spawnIntervalForLevel(level)
+        : Math.max(600, 2200 * Math.pow(0.94, level));
+      let interval = baseInterval;
       if(state.skillHasteUntil > performance.now()) interval *= 0.5;
-      if(interval<600) interval=600;
       clearInterval(state.timers.spawn); state.timers.spawn = setInterval(spawnOre, interval);
     }
     function exitRun(){ if(!state.inRun) return; bankAndExit(false); }


### PR DESCRIPTION
## Summary
- reduce the spawn interval upgrade to progress in 0.05 second steps while keeping the 0.5 second minimum via a 34-level cap
- remove the "다음" text and units from future bonus previews so parentheses show only the raw change values

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8d958d22883328f3612518dfe3092