### PR TITLE
Fix pet strafing radial correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -2440,7 +2440,10 @@ section[id^="tab-"].active{ display:block; }
             const perpY = axisX;
             const strafeSpeed = PET.moveSpeed * 0.55;
             const radialError = dist - targetRadius;
-            const radialCorrection = Math.max(-PET.moveSpeed * 0.6, Math.min(PET.moveSpeed * 0.6, -radialError * 4));
+            const radialCorrection = Math.max(
+              -PET.moveSpeed * 0.6,
+              Math.min(PET.moveSpeed * 0.6, radialError * 4)
+            );
             const forwardOsc = Math.sin(p.strafeTimer * Math.PI * 2) * PET.moveSpeed * 0.2;
             const desiredVX = perpX * strafeSpeed * strafeDir + axisX * (forwardOsc + radialCorrection);
             const desiredVY = perpY * strafeSpeed * strafeDir + axisY * (forwardOsc + radialCorrection);


### PR DESCRIPTION
## Summary
- fix the sign on the radial correction term used during pet strafing so pets close in on ores instead of drifting away or diving through them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98ebc6c8c8332963552b20b38a932