### PR TITLE
Fix pet orbit to maintain consistent rotation

### DIFF
--- a/RoseOrbit.cs
+++ b/RoseOrbit.cs
@@ -66,21 +66,24 @@ public class RoseOrbit : MonoBehaviour
         currentCenter = Vector3.Lerp(currentCenter, desiredCenter, lerpFactor);
 
         float adjustedTheta = theta + phase;
-        float radius = A * Mathf.Cos(k * adjustedTheta);
+        float rawRadius = A * Mathf.Cos(k * adjustedTheta);
+        float angle = adjustedTheta;
 
-        if (minAbsR > 0f)
+        if (rawRadius < 0f)
         {
-            float sign = radius >= 0f ? 1f : -1f;
-            if (Mathf.Abs(radius) < minAbsR)
-            {
-                radius = sign * minAbsR;
-            }
+            rawRadius = -rawRadius;
+            angle += Mathf.PI;
         }
 
-        float cosTheta = Mathf.Cos(adjustedTheta);
-        float sinTheta = Mathf.Sin(adjustedTheta);
+        if (minAbsR > 0f && rawRadius < minAbsR)
+        {
+            rawRadius = minAbsR;
+        }
 
-        Vector3 offset = new Vector3(radius * cosTheta, radius * sinTheta, 0f);
+        float cosTheta = Mathf.Cos(angle);
+        float sinTheta = Mathf.Sin(angle);
+
+        Vector3 offset = new Vector3(rawRadius * cosTheta, rawRadius * sinTheta, 0f);
         Vector3 newPosition = currentCenter + offset;
         newPosition.z = transform.position.z;
 


### PR DESCRIPTION
## Summary
- keep the orbiting pet rotating in a single direction by normalizing negative rose-curve radii
- clamp the minimum radius after normalization to avoid cutting through the target

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d992fd07288332be51640881238577