### PR TITLE
Limit pet targeting speed to base movement rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,16 +2123,21 @@ section[id^="tab-"].active{ display:block; }
       const targetX = ore.x + dirX * radial;
       const targetY = ore.y + dirY * radial;
       const lerp = 1 - Math.exp(-followStrength * dt);
-      if(Number.isFinite(p.x)){
-        p.x += (targetX - p.x) * lerp;
-      } else {
-        p.x = targetX;
+      const maxStep = Math.max(0, PET.moveSpeed * dt);
+      const currentX = Number.isFinite(p.x) ? p.x : targetX;
+      const currentY = Number.isFinite(p.y) ? p.y : targetY;
+      let nextX = currentX + (targetX - currentX) * lerp;
+      let nextY = currentY + (targetY - currentY) * lerp;
+      const stepX = nextX - currentX;
+      const stepY = nextY - currentY;
+      const stepDist = Math.hypot(stepX, stepY);
+      if(stepDist > maxStep && stepDist > 0){
+        const scale = maxStep / stepDist;
+        nextX = currentX + stepX * scale;
+        nextY = currentY + stepY * scale;
       }
-      if(Number.isFinite(p.y)){
-        p.y += (targetY - p.y) * lerp;
-      } else {
-        p.y = targetY;
-      }
+      p.x = nextX;
+      p.y = nextY;
       p.x = clamp(p.x, 8, gridWidth - 8);
       p.y = clamp(p.y, 8, gridHeight - 8);
       const prevContact = !!p.prevContact;


### PR DESCRIPTION
## Summary
- clamp pet orbit repositioning so their travel speed is limited to the base move speed
- keep lerp-based orbiting while ensuring movement never exceeds the defined per-second speed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da1152fbfc8332aab4e5b41f88092c