### PR TITLE
Tweak pet movement speed and targeting behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,7 +641,7 @@ section[id^="tab-"].active{ display:block; }
     }
 
     const PET = {
-      moveSpeed: 240,
+      moveSpeed: 180,
       atkInterval: 0.5,
       sepRadius: 24,
       atkRange: 18,
@@ -2020,8 +2020,11 @@ section[id^="tab-"].active{ display:block; }
         pet.radiusScale = Number.isFinite(pet.radiusScale) ? pet.radiusScale : 1;
         const baseRadius = Math.max(ORE_RADIUS + 12, PET.swingRadius * 0.9);
         pet.maxRadius = baseRadius * Math.max(0.6, Math.min(1.4, pet.radiusScale));
-        pet.contactRadius = Math.max(ORE_RADIUS + 4, pet.maxRadius * 0.82);
-        pet.followStrength = Math.max(4, Number.isFinite(pet.followStrength) ? pet.followStrength : 12);
+        const defaultContact = ORE_RADIUS + Math.min(2, PET.atkRange * 0.25);
+        const desiredContact = Number.isFinite(pet.contactRadius) ? pet.contactRadius : defaultContact;
+        pet.contactRadius = Math.max(ORE_RADIUS + 2, Math.min(pet.maxRadius - 1, desiredContact));
+        const followBase = Number.isFinite(pet.followStrength) ? pet.followStrength : (PET.moveSpeed / 24);
+        pet.followStrength = Math.max(3, followBase);
         pet.prevRadial = 0;
         pet.prevContact = false;
         pet.lastHitMs = -1;
@@ -2107,7 +2110,8 @@ section[id^="tab-"].active{ display:block; }
       const gridWidth = Math.max(gr.width || 0, 16);
       const gridHeight = Math.max(gr.height || 0, 16);
       const maxRadius = Math.max(ORE_RADIUS + 8, Number.isFinite(p.maxRadius) ? p.maxRadius : PET.swingRadius);
-      const followStrength = Math.max(4, Number.isFinite(p.followStrength) ? p.followStrength : 12);
+      const followBase = Number.isFinite(p.followStrength) ? p.followStrength : (PET.moveSpeed / 24);
+      const followStrength = Math.max(3, followBase);
       const orbitSpeed = Math.max(0.3, Number.isFinite(p.orbitSpeed) ? p.orbitSpeed : (PET.moveSpeed / Math.max(ORE_RADIUS + 8, maxRadius)) * 0.55);
       const dir = (Number.isFinite(p.orbitDir) && p.orbitDir < 0) ? -1 : 1;
       const baseX = Number.isFinite(p.x) ? p.x : ore.x;
@@ -2141,10 +2145,12 @@ section[id^="tab-"].active{ display:block; }
       p.x = clamp(p.x, 8, gridWidth - 8);
       p.y = clamp(p.y, 8, gridHeight - 8);
       const prevContact = !!p.prevContact;
-      const contactRadius = Math.max(ORE_RADIUS + 4, Number.isFinite(p.contactRadius) ? p.contactRadius : maxRadius * 0.82);
-      const radialAbs = Math.abs(radial);
+      const contactRadius = Math.max(ORE_RADIUS + 2, Number.isFinite(p.contactRadius) ? p.contactRadius : (ORE_RADIUS + Math.min(2, PET.atkRange * 0.25)));
+      const dx = p.x - ore.x;
+      const dy = p.y - ore.y;
+      const distance = Math.hypot(dx, dy);
       const timeSinceHit = Number.isFinite(p.lastHitMs) ? (ts - p.lastHitMs) / 1000 : Infinity;
-      const contactNow = radialAbs >= contactRadius;
+      const contactNow = distance <= contactRadius;
       if(contactNow && !prevContact && timeSinceHit >= Math.max(0.1, PET.atkInterval * 0.35) && p.targetIdx >= 0){
         hit(p.targetIdx,'pet',{ damageMul: p.damageMul || 1 });
         p.lastHitMs = ts;
@@ -2160,7 +2166,8 @@ section[id^="tab-"].active{ display:block; }
       const centerY = gridHeight / 2;
       const dir = (Number.isFinite(p.orbitDir) && p.orbitDir < 0) ? -1 : 1;
       const orbitSpeed = Math.max(0.25, Number.isFinite(p.orbitSpeed) ? p.orbitSpeed * 0.6 : 0.8);
-      const followStrength = Math.max(4, Number.isFinite(p.followStrength) ? p.followStrength * 0.6 : 8);
+      const followBase = Number.isFinite(p.followStrength) ? p.followStrength : (PET.moveSpeed / 24);
+      const followStrength = Math.max(3, followBase * 0.6);
       const angle = (Number.isFinite(p.orbitAngle) ? p.orbitAngle : Math.random() * Math.PI * 2) + orbitSpeed * dt * dir;
       p.orbitAngle = angle;
       const petalCount = Math.max(1, Number.isFinite(p.petalCount) ? Math.round(p.petalCount) : 3);
@@ -2174,16 +2181,21 @@ section[id^="tab-"].active{ display:block; }
       const targetX = centerX + dirX * radial;
       const targetY = centerY + dirY * radial;
       const lerp = 1 - Math.exp(-followStrength * dt);
-      if(Number.isFinite(p.x)){
-        p.x += (targetX - p.x) * lerp;
-      } else {
-        p.x = targetX;
+      const currentX = Number.isFinite(p.x) ? p.x : targetX;
+      const currentY = Number.isFinite(p.y) ? p.y : targetY;
+      let nextX = currentX + (targetX - currentX) * lerp;
+      let nextY = currentY + (targetY - currentY) * lerp;
+      const maxStep = Math.max(0, PET.moveSpeed * dt);
+      const stepX = nextX - currentX;
+      const stepY = nextY - currentY;
+      const stepDist = Math.hypot(stepX, stepY);
+      if(stepDist > maxStep && stepDist > 0){
+        const scale = maxStep / stepDist;
+        nextX = currentX + stepX * scale;
+        nextY = currentY + stepY * scale;
       }
-      if(Number.isFinite(p.y)){
-        p.y += (targetY - p.y) * lerp;
-      } else {
-        p.y = targetY;
-      }
+      p.x = nextX;
+      p.y = nextY;
       p.x = clamp(p.x, 8, gridWidth - 8);
       p.y = clamp(p.y, 8, gridHeight - 8);
       p.prevContact = false;


### PR DESCRIPTION
## Summary
- reduce the base pet movement speed and derive default follow strength from it
- tighten the pet contact radius and check actual distance before triggering attacks
- limit idle repositioning to the movement speed for smoother returns to center

## Testing
- Not Run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da130f6db88332bf2994dbf79f0810