### PR TITLE
Adjust ore health scaling rates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1790,7 +1790,7 @@ section[id^="tab-"].active{ display:block; }
     function etherHpForFloor(){
       const baseHp = 500;
       const floorOffset = Math.max(0, state.floor - 1);
-      const scale = Math.pow(1.1, floorOffset);
+      const scale = Math.pow(1.2, floorOffset);
       return Math.round(baseHp * scale);
     }
 
@@ -1961,7 +1961,7 @@ section[id^="tab-"].active{ display:block; }
       const pool = eligibleOresForFloor(state.floor);
       const base = randWeighted(pool);
       const elapsed = (performance.now() - state.runStartTs)/1000;
-      const growth = 1 + 0.02 * Math.max(0, Math.floor(elapsed));
+      const growth = 1 + 0.05 * Math.max(0, Math.floor(elapsed));
       const hp = Math.round(base.hp*floorHpMul()*growth*(state.skillAtkBuffUntil>performance.now()?0.9:1));
       const value = Math.round(base.value*floorValMul());
       const gr = gridRect();


### PR DESCRIPTION
## Summary
- increase the per-second ore HP growth factor to 5%
- raise the ether floor HP scaling multiplier to 1.2 per floor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da20d581388332b0b76467e60157b1