### PR TITLE
Exclude special pets from gold upgrade count

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -238,7 +238,7 @@ window.UPGRADE_INFO = [
     getDescription: (state) => {
       const level = getUpgradeLevel(state, 'pet');
       const max = UPGRADE_CONFIG.pet.maxLevel || 0;
-      const current = level + (state.passive?.petPlus || 0) + (state.aether?.petPlus || 0);
+      const current = level + (state.passive?.petPlus || 0);
       const hasNext = !max || level < max;
       const suffix = hasNext ? ' (+1)' : '';
       return `보유: ${current}마리${suffix}`;


### PR DESCRIPTION
## Summary
- stop counting special pets from the gold upgrade auto-mining pet total display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da40b9a894833285fa8233f57428d6