### PR TITLE
Fix ore spawn bounds and keep pets inside dungeon

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,6 +726,8 @@ section[id^="tab-"].active{ display:block; }
 
     const ORE_SIZE = 52;
     const ORE_RADIUS = ORE_SIZE / 2;
+    const PET_SIZE = 16;
+    const PET_RADIUS = PET_SIZE / 2;
     const GRID_SAFE_MARGIN = 6;
 
     function parseCssPx(v){
@@ -741,12 +743,40 @@ section[id^="tab-"].active{ display:block; }
         const padRight = parseCssPx(style.paddingRight);
         const padTop = parseCssPx(style.paddingTop);
         const padBottom = parseCssPx(style.paddingBottom);
+        const borderLeft = parseCssPx(style.borderLeftWidth);
+        const borderRight = parseCssPx(style.borderRightWidth);
+        const borderTop = parseCssPx(style.borderTopWidth);
+        const borderBottom = parseCssPx(style.borderBottomWidth);
         const radiusTL = parseCssPx(style.borderTopLeftRadius);
         const radiusTR = parseCssPx(style.borderTopRightRadius);
         const radiusBL = parseCssPx(style.borderBottomLeftRadius);
         const radiusBR = parseCssPx(style.borderBottomRightRadius);
-        const safeX = Math.max(GRID_SAFE_MARGIN, padLeft, padRight, radiusTL, radiusTR, radiusBL, radiusBR);
-        const safeY = Math.max(GRID_SAFE_MARGIN, padTop, padBottom, radiusTL, radiusTR, radiusBL, radiusBR);
+        const safeX = Math.max(
+          GRID_SAFE_MARGIN,
+          padLeft + borderLeft,
+          padRight + borderRight,
+          radiusTL + borderLeft,
+          radiusTR + borderRight,
+          radiusBL + borderLeft,
+          radiusBR + borderRight,
+          radiusTL,
+          radiusTR,
+          radiusBL,
+          radiusBR
+        );
+        const safeY = Math.max(
+          GRID_SAFE_MARGIN,
+          padTop + borderTop,
+          padBottom + borderBottom,
+          radiusTL + borderTop,
+          radiusTR + borderTop,
+          radiusBL + borderBottom,
+          radiusBR + borderBottom,
+          radiusTL,
+          radiusTR,
+          radiusBL,
+          radiusBR
+        );
         gridSafeMargin = { x: safeX, y: safeY };
       }catch(e){ gridSafeMargin = { x: GRID_SAFE_MARGIN, y: GRID_SAFE_MARGIN }; }
       return gridSafeMargin;
@@ -773,15 +803,17 @@ section[id^="tab-"].active{ display:block; }
       return a;
     }
 
-    function spawnAxisInfo(size, desiredMargin = GRID_SAFE_MARGIN){
+    function spawnAxisInfo(size, desiredMargin = GRID_SAFE_MARGIN, entitySize = ORE_SIZE){
       const actual = Math.max(0, size || 0);
       const desired = Math.max(0, Number.isFinite(desiredMargin) ? desiredMargin : GRID_SAFE_MARGIN);
-      const available = Math.max(0, actual - ORE_SIZE);
+      const objectSize = Math.max(0, Number.isFinite(entitySize) ? entitySize : ORE_SIZE);
+      const radius = objectSize / 2;
+      const available = Math.max(0, actual - objectSize);
       const margin = Math.min(desired, available / 2);
-      const minCenter = ORE_RADIUS + margin;
-      const maxCenter = Math.max(minCenter, actual - (ORE_RADIUS + margin));
+      const minCenter = radius + margin;
+      const maxCenter = Math.max(minCenter, actual - (radius + margin));
       const span = Math.max(0, maxCenter - minCenter);
-      return { start: minCenter, span, min: minCenter, max: maxCenter, size: actual, margin };
+      return { start: minCenter, span, min: minCenter, max: maxCenter, size: actual, margin, radius, objectSize };
     }
 
     function clampAxisValue(val, axis){
@@ -810,6 +842,22 @@ section[id^="tab-"].active{ display:block; }
       const maxCenterY = Math.max(minCenterY, gridHeight - (ORE_RADIUS + marginY));
       ore.x = Math.min(Math.max(ore.x, minCenterX), maxCenterX);
       ore.y = Math.min(Math.max(ore.y, minCenterY), maxCenterY);
+    }
+
+    function clampPetToGrid(pet, axisX, axisY){
+      if(!pet) return;
+      const gridWidth = axisX?.size ?? gridRectCache?.width ?? lastGridRectValid?.width ?? PET_SIZE;
+      const gridHeight = axisY?.size ?? gridRectCache?.height ?? lastGridRectValid?.height ?? PET_SIZE;
+      const marginX = Number.isFinite(axisX?.margin) ? axisX.margin : Math.min(GRID_SAFE_MARGIN, Math.max(0, (gridWidth - PET_SIZE) / 2));
+      const marginY = Number.isFinite(axisY?.margin) ? axisY.margin : Math.min(GRID_SAFE_MARGIN, Math.max(0, (gridHeight - PET_SIZE) / 2));
+      const minCenterX = Number.isFinite(axisX?.min) ? axisX.min : PET_RADIUS + marginX;
+      const maxCenterX = Number.isFinite(axisX?.max) ? axisX.max : Math.max(minCenterX, gridWidth - (PET_RADIUS + marginX));
+      const minCenterY = Number.isFinite(axisY?.min) ? axisY.min : PET_RADIUS + marginY;
+      const maxCenterY = Number.isFinite(axisY?.max) ? axisY.max : Math.max(minCenterY, gridHeight - (PET_RADIUS + marginY));
+      const safeX = Number.isFinite(pet.x) ? pet.x : minCenterX;
+      const safeY = Number.isFinite(pet.y) ? pet.y : minCenterY;
+      pet.x = Math.min(Math.max(safeX, minCenterX), maxCenterX);
+      pet.y = Math.min(Math.max(safeY, minCenterY), maxCenterY);
     }
 
     const playGamesCardEl = document.getElementById('playGamesCard');
@@ -1048,15 +1096,20 @@ section[id^="tab-"].active{ display:block; }
               ore.y = newAxisY.start + ny * (newAxisY.span || 0);
               clampOreToGrid(ore, newAxisX, newAxisY);
             }
-            const oldPetW = Math.max(1, prev.width - 16);
-            const oldPetH = Math.max(1, prev.height - 16);
-            const newPetW = Math.max(1, r.width - 16);
-            const newPetH = Math.max(1, r.height - 16);
+            const oldPetAxisX = spawnAxisInfo(prev.width, prevMarginX, PET_SIZE);
+            const oldPetAxisY = spawnAxisInfo(prev.height, prevMarginY, PET_SIZE);
+            const newPetAxisX = spawnAxisInfo(r.width, newMargins.x, PET_SIZE);
+            const newPetAxisY = spawnAxisInfo(r.height, newMargins.y, PET_SIZE);
             for(const pet of state.pets){
-              const nx = Math.max(0, Math.min(1, (pet.x - 8) / oldPetW));
-              const ny = Math.max(0, Math.min(1, (pet.y - 8) / oldPetH));
-              pet.x = 8 + nx * newPetW;
-              pet.y = 8 + ny * newPetH;
+              const oldSpanX = oldPetAxisX.span || 0;
+              const oldSpanY = oldPetAxisY.span || 0;
+              const nx = oldSpanX > 0 ? Math.max(0, Math.min(1, (pet.x - oldPetAxisX.start) / oldSpanX)) : 0.5;
+              const ny = oldSpanY > 0 ? Math.max(0, Math.min(1, (pet.y - oldPetAxisY.start) / oldSpanY)) : 0.5;
+              const newSpanX = newPetAxisX.span || 0;
+              const newSpanY = newPetAxisY.span || 0;
+              pet.x = newPetAxisX.start + Math.max(0, Math.min(1, nx)) * newSpanX;
+              pet.y = newPetAxisY.start + Math.max(0, Math.min(1, ny)) * newSpanY;
+              clampPetToGrid(pet, newPetAxisX, newPetAxisY);
             }
           }
         }
@@ -2074,12 +2127,16 @@ section[id^="tab-"].active{ display:block; }
       const baseCount = getUpgradeLevel(state, 'pet') + (state.passive.petPlus || 0);
       const specialCount = Math.max(0, state.aether?.petPlus || 0);
       const gr = gridRect();
-      const width = Math.max(16, gr.width);
-      const height = Math.max(16, gr.height);
+      const width = Math.max(0, gr.width || 0);
+      const height = Math.max(0, gr.height || 0);
+      const margins = currentGridMargins();
+      const petAxisX = spawnAxisInfo(width, margins.x, PET_SIZE);
+      const petAxisY = spawnAxisInfo(height, margins.y, PET_SIZE);
+      const randomCenter = (axis) => axis.start + (axis.span>0 ? Math.random()*axis.span : 0);
 
       const createPet = (style = BASE_PET_STYLE) => ({
-        x: 8 + Math.random() * (width - 16),
-        y: 8 + Math.random() * (height - 16),
+        x: randomCenter(petAxisX),
+        y: randomCenter(petAxisY),
         targetIdx: -1,
         orbitAngle: Math.random() * Math.PI * 2,
         orbitDir: Math.random() < 0.5 ? 1 : -1,
@@ -2121,9 +2178,10 @@ section[id^="tab-"].active{ display:block; }
         pet.prevContact = false;
         pet.lastHitMs = -1;
         if(!Number.isFinite(pet.x) || !Number.isFinite(pet.y)){
-          pet.x = 8 + Math.random() * (width - 16);
-          pet.y = 8 + Math.random() * (height - 16);
+          pet.x = randomCenter(petAxisX);
+          pet.y = randomCenter(petAxisY);
         }
+        clampPetToGrid(pet, petAxisX, petAxisY);
         pet.targetIdx = -1;
         return pet;
       };
@@ -2139,13 +2197,17 @@ section[id^="tab-"].active{ display:block; }
     }
     function renderPets(){
       gridEl.querySelectorAll('.pet').forEach(p=>p.remove());
-      gridRect();
+      const gr = gridRect();
+      const margins = currentGridMargins();
+      const axisX = spawnAxisInfo(gr.width, margins.x, PET_SIZE);
+      const axisY = spawnAxisInfo(gr.height, margins.y, PET_SIZE);
       for(const p of state.pets){
+        clampPetToGrid(p, axisX, axisY);
         const el=document.createElement('div');
         el.className='pet';
         if(p.special) el.classList.add('pet-special');
-        const localX = p.x - 8;
-        const localY = p.y - 8;
+        const localX = p.x - PET_RADIUS;
+        const localY = p.y - PET_RADIUS;
         el.style.transform = `translate(${localX}px, ${localY}px)`;
         if(p.color) el.style.background = p.color;
         if(p.borderColor) el.style.borderColor = p.borderColor;
@@ -2197,7 +2259,7 @@ section[id^="tab-"].active{ display:block; }
       return findNearestOreFromList(p.x, p.y, oreIndices);
     }
 
-    function updatePetOrbitMotion(p, ore, dt, ts, gr){
+    function updatePetOrbitMotion(p, ore, dt, ts, gr, axisX, axisY){
       if(!p || !ore) return;
       const gridWidth = Math.max(gr.width || 0, 16);
       const gridHeight = Math.max(gr.height || 0, 16);
@@ -2235,8 +2297,7 @@ section[id^="tab-"].active{ display:block; }
       }
       p.x = nextX;
       p.y = nextY;
-      p.x = clamp(p.x, 8, gridWidth - 8);
-      p.y = clamp(p.y, 8, gridHeight - 8);
+      clampPetToGrid(p, axisX, axisY);
       const prevContact = !!p.prevContact;
       const contactRadius = Math.max(ORE_RADIUS + 2, Number.isFinite(p.contactRadius) ? p.contactRadius : (ORE_RADIUS + Math.min(2, PET.atkRange * 0.25)));
       const dx = p.x - ore.x;
@@ -2251,7 +2312,7 @@ section[id^="tab-"].active{ display:block; }
       p.prevContact = contactNow;
       p.prevRadial = radial;
     }
-    function updatePetIdleMotion(p, dt, gr){
+    function updatePetIdleMotion(p, dt, gr, axisX, axisY){
       const gridWidth = Math.max(gr.width || 0, 16);
       const gridHeight = Math.max(gr.height || 0, 16);
       const minDimension = Math.min(gridWidth, gridHeight);
@@ -2289,8 +2350,7 @@ section[id^="tab-"].active{ display:block; }
       }
       p.x = nextX;
       p.y = nextY;
-      p.x = clamp(p.x, 8, gridWidth - 8);
-      p.y = clamp(p.y, 8, gridHeight - 8);
+      clampPetToGrid(p, axisX, axisY);
       p.prevContact = false;
       p.prevRadial = 0;
     }
@@ -2301,6 +2361,9 @@ section[id^="tab-"].active{ display:block; }
         return;
       }
       const gr = gridRect();
+      const margins = currentGridMargins();
+      const petAxisX = spawnAxisInfo(gr.width, margins.x, PET_SIZE);
+      const petAxisY = spawnAxisInfo(gr.height, margins.y, PET_SIZE);
       const dt = Math.min(0.05,(ts - state.lastAnimTs)/1000 || 0.016);
       state.lastAnimTs = ts;
       const oreIndices = [];
@@ -2342,9 +2405,9 @@ section[id^="tab-"].active{ display:block; }
       for(const p of state.pets){
         const ore = (p.targetIdx>=0) ? state.grid[p.targetIdx] : null;
         if(ore){
-          updatePetOrbitMotion(p, ore, dt, ts, gr);
+          updatePetOrbitMotion(p, ore, dt, ts, gr, petAxisX, petAxisY);
         } else {
-          updatePetIdleMotion(p, dt, gr);
+          updatePetIdleMotion(p, dt, gr, petAxisX, petAxisY);
         }
       }
       renderPets();


### PR DESCRIPTION
## Summary
- adjust safe margin computation to include grid borders so ores spawn away from the edges
- reuse generalized spawn axis information to clamp pet spawning, movement, and resizing inside the dungeon

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68da49a21de083329327fdf2b48b4a40