### PR TITLE
Trigger auto skills immediately on dungeon start

### DIFF
--- a/index.html
+++ b/index.html
@@ -1905,6 +1905,7 @@ section[id^="tab-"].active{ display:block; }
       renderSkillBar();
       gridRectCache = null;
       spawnPets();
+      maybeHandleAutoSkills();
       refresh();
     }
 


### PR DESCRIPTION
## Summary
- trigger the auto-skill handler right after a dungeon run begins so toggled skills fire immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5b07f780833292db7514c12a1f09