### PR TITLE
Clarify ore spawn interval display

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -203,7 +203,24 @@ window.UPGRADE_INFO = [
       const delta = current - next;
       const hasNext = !max || level < max;
       const suffix = hasNext && delta > 0 ? ` (-${(delta / 1000).toFixed(2)})` : '';
-      return `현재 생성 간격: ${(current / 1000).toFixed(2)}초${suffix}`;
+      const formatSeconds = (ms) => {
+        if(typeof ms !== 'number' || !Number.isFinite(ms)) return '--';
+        return (ms / 1000).toFixed(2);
+      };
+      let desc = `현재 생성 간격: ${formatSeconds(current)}초${suffix}`;
+      if(state && state.inRun){
+        const active = (typeof state.currentSpawnIntervalMs === 'number' && Number.isFinite(state.currentSpawnIntervalMs))
+          ? state.currentSpawnIntervalMs
+          : current;
+        const diff = Math.abs(active - current);
+        if(diff > 1){
+          const hasteNote = state?.runFlags?.hasteActive ? ', 가속 효과 적용중' : '';
+          desc += ` (실제: ${formatSeconds(active)}초${hasteNote})`;
+        } else if(state?.runFlags?.hasteActive){
+          desc += ' (가속 효과 적용중)';
+        }
+      }
+      return desc;
     },
     getCost: (state) => upgradeCostLinear(state, 'spawn'),
     canBuy: (state) => {

--- a/index.html
+++ b/index.html
@@ -544,6 +544,8 @@ section[id^="tab-"].active{ display:block; }
       skillHasteUntil: 0,
       skillAtkBuffUntil: 0,
 
+      currentSpawnIntervalMs: 0,
+
       // Passive bonuses
       passive: { sellBonus: 0, petPlus: 0, berserkUnlimit:false },
 
@@ -604,6 +606,14 @@ section[id^="tab-"].active{ display:block; }
     ensurePassiveDefaults();
     ensureSkillAutoDefaults();
     resetRunFlags();
+
+    state.currentSpawnIntervalMs = (() => {
+      const level = getUpgradeLevel(state, 'spawn');
+      if(typeof window.spawnIntervalForLevel === 'function'){
+        return window.spawnIntervalForLevel(level);
+      }
+      return Math.max(600, 2200 * Math.pow(0.94, level));
+    })();
 
     // ---------- Save/Load (stable key + migration) ----------
     function save(){
@@ -2015,13 +2025,22 @@ section[id^="tab-"].active{ display:block; }
       startTick();
     }
 
-    function restartSpawnTimer(){
+    function getBaseSpawnIntervalMs(){
       const level = getUpgradeLevel(state, 'spawn');
-      const baseInterval = (typeof window.spawnIntervalForLevel === 'function')
-        ? window.spawnIntervalForLevel(level)
-        : Math.max(600, 2200 * Math.pow(0.94, level));
+      if(typeof window.spawnIntervalForLevel === 'function'){
+        return window.spawnIntervalForLevel(level);
+      }
+      return Math.max(600, 2200 * Math.pow(0.94, level));
+    }
+
+    function restartSpawnTimer(){
+      const baseInterval = getBaseSpawnIntervalMs();
       let interval = baseInterval;
-      if(state.skillHasteUntil > performance.now()) interval *= 0.5;
+      const now = (typeof performance !== 'undefined' && typeof performance.now === 'function')
+        ? performance.now()
+        : Date.now();
+      if(state.skillHasteUntil > now) interval *= 0.5;
+      state.currentSpawnIntervalMs = interval;
       clearInterval(state.timers.spawn); state.timers.spawn = setInterval(spawnOre, interval);
     }
     function exitRun(){ if(!state.inRun) return; bankAndExit(false); }
@@ -2047,6 +2066,7 @@ section[id^="tab-"].active{ display:block; }
       setRunTime(0);
       state.pets=[]; state.lastAnimTs=0; state.grid = new Array(25).fill(null);
       if(cleared){ state.floor++; if(state.floor>state.highestFloor) state.highestFloor=state.floor; }
+      state.currentSpawnIntervalMs = getBaseSpawnIntervalMs();
       save();
       renderSkillBar();
       gridRectCache = null;
@@ -2066,6 +2086,7 @@ section[id^="tab-"].active{ display:block; }
       state.lastAnimTs = 0;
       state.grid = new Array(25).fill(null);
       setRunTime(0);
+      state.currentSpawnIntervalMs = getBaseSpawnIntervalMs();
       renderSkillBar();
       gridRectCache = null;
       refresh();


### PR DESCRIPTION
## Summary
- track the actual ore spawn timer interval so it stays in sync with haste effects
- surface the effective interval in the spawn speed upgrade description to explain faster spawns

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da7df6ebf88332b72b013cfc5ea064