### PR TITLE
Add typed confirmation for game reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -2731,7 +2731,16 @@ section[id^="tab-"].active{ display:block; }
       bankAndExit(false);
     });
     $('#saveBtn').addEventListener('click', ()=>{ SFX.ui(); save(); });
-    $('#resetBtn').addEventListener('click', ()=>{ SFX.ui(); if(confirm('정말 전체 초기화할까요? (세이브 전부 삭제)')){ try{ localStorage.removeItem(SAVE_KEY); }catch(e){} try{ LEGACY_KEYS.forEach(k=>localStorage.removeItem(k)); }catch(e){} location.reload(); } });
+    $('#resetBtn').addEventListener('click', ()=>{
+      SFX.ui();
+      const answer = prompt('정말 전체 초기화할까요? (세이브 전부 삭제)\n초기화를 원하면 reset 을 입력하세요.');
+      if(answer && answer.trim().toLowerCase() === 'reset'){
+        try{ localStorage.removeItem(SAVE_KEY); }catch(e){}
+        try{ LEGACY_KEYS.forEach(k=>localStorage.removeItem(k)); }catch(e){}
+        alert('세이브가 초기화되었습니다.');
+        location.reload();
+      }
+    });
     $('#fullscreenBtn').addEventListener('click', ()=>{ SFX.ui(); if(!document.fullscreenElement){ document.documentElement.requestFullscreen?.(); } else { document.exitFullscreen?.(); } });
     $('#toggleSoundBtn').addEventListener('click', ()=>{
       SFX.ui();


### PR DESCRIPTION
## Summary
- require users to type "reset" before clearing all save data
- alert players that the save has been cleared prior to reloading the page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daacaea9a08332922572dc0e5e8c82