### PR TITLE
Fix pet behavior upgrade not applying on new dungeon runs

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -436,7 +436,7 @@ window.UPGRADE_INFO = [
   },
   {
     key: 'petAi',
-    title: '🧠 펫 행동 알고리즘',
+    title: '🧠 똑똑한 펫',
     getLevel: (state) => getUpgradeLevel(state, 'petAi'),
     getLevelLabel: (state) => `Lv ${getUpgradeLevel(state, 'petAi')}`,
     getDescription: (state) => {

--- a/index.html
+++ b/index.html
@@ -2614,6 +2614,9 @@ section[id^="tab-"].active{ display:block; }
         state.pets.push(initPetMotion(createPet({ ...styleDef, damageMul: 2, special: true, styleIndex: i })));
       }
       renderPets();
+      if(typeof applyPetBehaviorUpgrade === 'function'){
+        applyPetBehaviorUpgrade();
+      }
     }
     function renderPets(){
       gridEl.querySelectorAll('.pet').forEach(p=>p.remove());


### PR DESCRIPTION
## Summary
- rename the pet AI upgrade to "🧠 똑똑한 펫"
- ensure pet behavior upgrades are re-applied whenever pets respawn

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce0a0eecc833281bc9bce14099134