### PR TITLE
Improve meteor skill visuals and restrict sonic activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,22 @@
     .hp{position:absolute;top:6px;left:6px;right:6px;height:8px;background:rgba(0,0,0,.35);border-radius:999px;border:1px solid rgba(255,255,255,.08);overflow:hidden}
     .hp>div{height:100%;background:linear-gradient(90deg,#34d399,#f59e0b);width:100%}
 
-    .meteor-effect{position:absolute;width:36px;height:36px;border-radius:50%;background:radial-gradient(circle at 32% 28%,rgba(254,243,199,.95) 0%,rgba(253,186,116,.9) 32%,rgba(249,115,22,.85) 64%,rgba(124,45,18,.65) 100%);box-shadow:0 0 14px rgba(249,115,22,.7);transform-origin:center;opacity:.95;transition:transform .8s cubic-bezier(.22,.72,.23,1),opacity .3s ease-out;}
+    .meteor-effect{position:absolute;width:42px;height:42px;clip-path:polygon(18% 4%,82% 0%,100% 32%,76% 56%,88% 86%,46% 100%,12% 82%,0% 38%);background:radial-gradient(circle at 32% 28%,rgba(255,237,205,.92) 0%,rgba(255,163,120,.9) 38%,rgba(214,59,32,.9) 68%,rgba(94,18,8,.78) 100%);box-shadow:0 0 22px rgba(255,106,64,.68),0 0 46px rgba(219,54,24,.45);transform-origin:center;opacity:.96;transition:transform var(--meteor-travel-duration,0.8s) linear,opacity .28s ease-out;animation:meteor-core-pulse .52s linear infinite alternate;pointer-events:none;mix-blend-mode:screen;}
+    .meteor-effect::before{content:'';position:absolute;inset:-18% 20% -42% 10%;background:linear-gradient(180deg,rgba(255,198,142,.65) 0%,rgba(255,134,76,.35) 55%,rgba(124,28,8,0) 100%);filter:blur(4px);opacity:.85;transform:rotate(-6deg);border-radius:50%;}
+    .meteor-effect::after{content:'';position:absolute;inset:14% -48% 12% 28%;background:radial-gradient(circle at 0% 50%,rgba(255,160,120,.85) 0%,rgba(255,118,72,.45) 40%,rgba(255,98,48,0) 75%);filter:blur(2px);opacity:.9;}
     .meteor-effect.fading{opacity:0;}
-    .meteor-burst{position:absolute;width:48px;height:48px;border-radius:50%;background:radial-gradient(circle,rgba(254,243,199,.9) 0%,rgba(253,186,116,.5) 45%,rgba(249,115,22,0) 75%);transform:translate(-50%,-50%) scale(.6);opacity:.9;animation:meteor-burst .4s ease-out forwards;}
-    @keyframes meteor-burst{to{transform:translate(-50%,-50%) scale(1.6);opacity:0;}}
-    .meteor-fragment{position:absolute;width:10px;height:10px;border-radius:50%;background:radial-gradient(circle at 30% 30%,rgba(254,243,199,.95) 0%,rgba(249,115,22,.85) 60%,rgba(124,45,18,.75) 100%);box-shadow:0 0 8px rgba(249,115,22,.55);transform:translate(-50%,-50%) scale(.4);opacity:0;animation:meteor-fragment .6s ease-out forwards;}
-    .meteor-fragment::after{content:'';position:absolute;inset:20%;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.8) 0%,rgba(255,255,255,0) 70%);opacity:.8;}
-    @keyframes meteor-fragment{0%{opacity:1;transform:translate(-50%,-50%) scale(.55);}100%{opacity:0;transform:translate(calc(-50% + var(--fx-dx,0px)),calc(-50% + var(--fx-dy,0px))) scale(.25);}}
+    @keyframes meteor-core-pulse{from{filter:drop-shadow(0 0 18px rgba(255,124,78,.68));}to{filter:drop-shadow(0 0 26px rgba(255,74,44,.85));}}
+    .meteor-trail{position:absolute;height:28px;width:var(--meteor-trail-length,140px);border-radius:999px;background:linear-gradient(90deg,rgba(255,94,44,0) 0%,rgba(255,122,70,.38) 18%,rgba(255,108,58,.7) 52%,rgba(199,46,18,.45) 78%,rgba(120,18,12,0) 100%);filter:blur(1.2px) drop-shadow(0 0 16px rgba(255,104,48,.55));opacity:.78;transform-origin:0% 50%;pointer-events:none;mix-blend-mode:screen;animation:meteor-trail-fade var(--meteor-trail-life,.9s) ease-out forwards;}
+    @keyframes meteor-trail-fade{0%{opacity:.6;}40%{opacity:.95;}100%{opacity:0;filter:blur(6px);}}
+    .meteor-burst{position:absolute;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,237,205,.95) 0%,rgba(255,172,120,.65) 45%,rgba(255,106,68,.15) 74%,rgba(255,88,50,0) 100%);transform:translate(-50%,-50%) scale(.6);opacity:.95;animation:meteor-burst .48s ease-out forwards;mix-blend-mode:screen;box-shadow:0 0 28px rgba(255,134,86,.58),0 0 60px rgba(255,90,54,.32);}
+    @keyframes meteor-burst{to{transform:translate(-50%,-50%) scale(2.1);opacity:0;filter:blur(16px);}}
+    .meteor-flare{position:absolute;width:96px;height:96px;border-radius:50%;background:radial-gradient(circle,rgba(255,204,158,.85) 0%,rgba(255,121,70,.5) 40%,rgba(142,28,12,0) 70%);transform:translate(-50%,-50%) scale(.5);opacity:.9;animation:meteor-flare .52s ease-out forwards;pointer-events:none;mix-blend-mode:screen;}
+    @keyframes meteor-flare{to{transform:translate(-50%,-50%) scale(1.9);opacity:0;filter:blur(18px);}}
+    .meteor-shockwave{position:absolute;width:78px;height:78px;border:3px solid rgba(255,214,180,.85);border-radius:50%;transform:translate(-50%,-50%) scale(.55);opacity:.85;animation:meteor-shockwave .5s ease-out forwards;pointer-events:none;box-shadow:0 0 24px rgba(255,156,100,.42);}
+    @keyframes meteor-shockwave{to{transform:translate(-50%,-50%) scale(2.45);opacity:0;border-width:0;filter:blur(8px);}}
+    .meteor-fragment{position:absolute;width:11px;height:11px;border-radius:50%;background:radial-gradient(circle at 28% 32%,rgba(255,236,204,.95) 0%,rgba(255,142,94,.85) 52%,rgba(168,38,18,.8) 100%);box-shadow:0 0 10px rgba(255,118,70,.55);transform:translate(-50%,-50%) scale(.4);opacity:0;animation:meteor-fragment .68s ease-out forwards;mix-blend-mode:screen;}
+    .meteor-fragment::after{content:'';position:absolute;inset:22%;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.82) 0%,rgba(255,255,255,0) 70%);opacity:.85;}
+    @keyframes meteor-fragment{0%{opacity:1;transform:translate(-50%,-50%) scale(.56);}100%{opacity:0;transform:translate(calc(-50% + var(--fx-dx,0px)),calc(-50% + var(--fx-dy,0px))) scale(.24);filter:blur(4px);}}
     .sonic-ring{position:absolute;width:52px;height:52px;border:2px solid rgba(255,255,255,.9);border-radius:50%;box-shadow:0 0 12px rgba(255,255,255,.35);transform:translate(-50%,-50%) scale(.25);opacity:.8;animation:sonic-ring .28s ease-out forwards;}
     @keyframes sonic-ring{to{transform:translate(-50%,-50%) scale(var(--ring-scale,2));opacity:0;}}
 
@@ -1706,8 +1715,20 @@ section[id^="tab-"].active{ display:block; }
         burst.style.left = cx + 'px';
         burst.style.top = cy + 'px';
         gridFxLayerEl.appendChild(burst);
-        setTimeout(()=>burst.remove(), 420);
-        spawnMeteorFragments(cx, cy, 12);
+        const flare = document.createElement('div');
+        flare.className = 'meteor-flare';
+        flare.style.left = cx + 'px';
+        flare.style.top = cy + 'px';
+        gridFxLayerEl.appendChild(flare);
+        const shockwave = document.createElement('div');
+        shockwave.className = 'meteor-shockwave';
+        shockwave.style.left = cx + 'px';
+        shockwave.style.top = cy + 'px';
+        gridFxLayerEl.appendChild(shockwave);
+        setTimeout(()=>burst.remove(), 520);
+        setTimeout(()=>flare.remove(), 560);
+        setTimeout(()=>shockwave.remove(), 520);
+        spawnMeteorFragments(cx, cy, 16);
       }
       if(typeof onImpact === 'function'){
         onImpact();
@@ -1729,9 +1750,26 @@ section[id^="tab-"].active{ display:block; }
       const centerY = height / 2;
       const meteor = document.createElement('div');
       meteor.className = 'meteor-effect';
-      const size = 36;
+      const size = 42;
       const half = size / 2;
-      meteor.style.transform = `translate(${startX - half}px, ${startY - half}px) scale(0.25)`;
+      const dx = centerX - startX;
+      const dy = centerY - startY;
+      const distance = Math.hypot(dx, dy);
+      const angle = Math.atan2(dy, dx);
+      const travelSpeed = 420;
+      const travelDuration = Math.max(0.35, distance / travelSpeed);
+      const trailLife = Math.max(travelDuration + 0.25, 0.6);
+      const trail = document.createElement('div');
+      trail.className = 'meteor-trail';
+      trail.style.left = `${startX}px`;
+      trail.style.top = `${startY}px`;
+      trail.style.transform = `translateY(-50%) rotate(${angle}rad)`;
+      trail.style.setProperty('--meteor-trail-length', `${Math.max(distance + size * 0.6, 80)}px`);
+      trail.style.setProperty('--meteor-trail-life', `${trailLife}s`);
+      trail.style.setProperty('--meteor-travel-duration', `${travelDuration}s`);
+      gridFxLayerEl.appendChild(trail);
+      meteor.style.setProperty('--meteor-travel-duration', `${travelDuration}s`);
+      meteor.style.transform = `translate(${startX - half}px, ${startY - half}px) rotate(${angle}rad) scale(0.45)`;
       gridFxLayerEl.appendChild(meteor);
       let impacted = false;
       const impactNow = () => {
@@ -1739,15 +1777,16 @@ section[id^="tab-"].active{ display:block; }
         impacted = true;
         meteor.classList.add('fading');
         triggerMeteorImpact(centerX, centerY, onImpact);
-        setTimeout(()=>meteor.remove(), 320);
+        setTimeout(()=>meteor.remove(), 360);
+        setTimeout(()=>trail.remove(), Math.round((trailLife + 0.2) * 1000));
       };
       requestAnimationFrame(()=>{
         requestAnimationFrame(()=>{
           meteor.addEventListener('transitionend', impactNow, { once: true });
-          meteor.style.transform = `translate(${centerX - half}px, ${centerY - half}px) scale(1.4)`;
+          meteor.style.transform = `translate(${centerX - half}px, ${centerY - half}px) rotate(${angle}rad) scale(1.18)`;
         });
       });
-      setTimeout(impactNow, 900);
+      setTimeout(impactNow, (travelDuration + 0.25) * 1000);
     }
 
     function spawnSonicRing(cx, cy, scale){
@@ -2506,21 +2545,16 @@ section[id^="tab-"].active{ display:block; }
           break;
         }
         case 'sonic': {
-          const gr = gridRect();
-          const cx = Math.max(0, (gr.innerWidth ?? gr.width) || 0) / 2;
-          const cy = Math.max(0, (gr.innerHeight ?? gr.height) || 0) / 2;
-          let targetIdx = state.grid.findIndex(o => o && o.type === 'EtherOre');
-          if(targetIdx < 0){
-            targetIdx = findNearestOreIdx(cx, cy);
-          }
-          if(targetIdx < 0){
+          const etherIdx = state.grid.findIndex(o => o && o.type === 'EtherOre');
+          if(etherIdx < 0){
             used = false;
             SFX.deny();
+            toast('에테르 광석이 감지되지 않았습니다.');
             return;
           }
-          const target = state.grid[targetIdx];
+          const target = state.grid[etherIdx];
           if(!target){ used = false; return; }
-          const center = cellCenter(targetIdx);
+          const center = cellCenter(etherIdx);
           const pulseCount = 5;
           const interval = 140;
           const radius = ORE_RADIUS * 2;


### PR DESCRIPTION
## Summary
- redesign the meteor skill effect with jagged visuals, fiery trail, and amplified impact burst
- ensure the meteor animation travels at a uniform speed toward the grid center
- gate the sonic skill behind ether ore detection and show a user-facing warning when unavailable

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0a5e8fcf08332aa0a041bbefa908c