### PR TITLE
Adjust meteor trail visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
     .hp{position:absolute;top:6px;left:6px;right:6px;height:8px;background:rgba(0,0,0,.35);border-radius:999px;border:1px solid rgba(255,255,255,.08);overflow:hidden}
     .hp>div{height:100%;background:linear-gradient(90deg,#34d399,#f59e0b);width:100%}
 
-    .meteor-effect{position:absolute;width:42px;height:42px;clip-path:polygon(18% 4%,82% 0%,100% 32%,76% 56%,88% 86%,46% 100%,12% 82%,0% 38%);background:radial-gradient(circle at 32% 28%,rgba(255,237,205,.92) 0%,rgba(255,163,120,.9) 38%,rgba(214,59,32,.9) 68%,rgba(94,18,8,.78) 100%);box-shadow:0 0 22px rgba(255,106,64,.68),0 0 46px rgba(219,54,24,.45);transform-origin:center;opacity:.96;transition:transform var(--meteor-travel-duration,0.8s) linear,opacity .28s ease-out;animation:meteor-core-pulse .52s linear infinite alternate;pointer-events:none;mix-blend-mode:screen;}
+    .meteor-effect{position:absolute;width:42px;height:42px;clip-path:polygon(18% 4%,82% 0%,100% 32%,76% 56%,88% 86%,46% 100%,12% 82%,0% 38%);background:radial-gradient(circle at 32% 28%,rgba(255,237,205,.92) 0%,rgba(255,163,120,.9) 38%,rgba(214,59,32,.9) 68%,rgba(94,18,8,.78) 100%);box-shadow:0 0 22px rgba(255,106,64,.68),0 0 46px rgba(219,54,24,.45);transform-origin:center;opacity:.96;transition:transform var(--meteor-travel-duration,0.8s) linear,opacity .28s ease-out;animation:meteor-core-pulse .52s linear infinite alternate;pointer-events:none;mix-blend-mode:screen;z-index:6;}
+    .meteor-echo{position:absolute;width:var(--meteor-echo-size,42px);height:var(--meteor-echo-size,42px);clip-path:polygon(50% 4%,95% 38%,78% 96%,22% 96%,5% 38%);background:radial-gradient(circle,rgba(255,72,72,.34) 0%,rgba(145,16,16,.28) 68%,rgba(115,12,12,0) 100%);border:1px solid rgba(255,116,116,.48);border-radius:50%;pointer-events:none;opacity:.55;mix-blend-mode:screen;transform-origin:center;transition:opacity .22s ease-out,transform .22s ease-out;z-index:5;}
     .meteor-effect::before{content:'';position:absolute;inset:-18% 20% -42% 10%;background:linear-gradient(180deg,rgba(255,198,142,.65) 0%,rgba(255,134,76,.35) 55%,rgba(124,28,8,0) 100%);filter:blur(4px);opacity:.85;transform:rotate(-6deg);border-radius:50%;}
     .meteor-effect::after{content:'';position:absolute;inset:14% -48% 12% 28%;background:radial-gradient(circle at 0% 50%,rgba(255,160,120,.85) 0%,rgba(255,118,72,.45) 40%,rgba(255,98,48,0) 75%);filter:blur(2px);opacity:.9;}
     .meteor-effect.fading{opacity:0;}
@@ -1735,6 +1736,31 @@ section[id^="tab-"].active{ display:block; }
       }
     }
 
+    function spawnMeteorEcho(x, y, size, meteorEl){
+      if(!gridFxLayerEl) return;
+      const echo = document.createElement('div');
+      echo.className = 'meteor-echo';
+      echo.style.left = x + 'px';
+      echo.style.top = y + 'px';
+      if(Number.isFinite(size)){
+        echo.style.setProperty('--meteor-echo-size', `${size}px`);
+      }
+      const rotation = (Math.random() * 360) - 180;
+      echo.style.transform = `translate(-50%, -50%) rotate(${rotation}deg) scale(1)`;
+      if(meteorEl && meteorEl.parentNode === gridFxLayerEl){
+        gridFxLayerEl.insertBefore(echo, meteorEl);
+      } else {
+        gridFxLayerEl.appendChild(echo);
+      }
+      requestAnimationFrame(()=>{
+        requestAnimationFrame(()=>{
+          echo.style.opacity = '0';
+          echo.style.transform = `translate(-50%, -50%) rotate(${rotation}deg) scale(0.72)`;
+        });
+      });
+      setTimeout(()=>echo.remove(), 260);
+    }
+
     function spawnMeteorSkillEffect(onImpact){
       if(!gridFxLayerEl || !gridEl){
         if(typeof onImpact === 'function') onImpact();
@@ -1758,35 +1784,50 @@ section[id^="tab-"].active{ display:block; }
       const angle = Math.atan2(dy, dx);
       const travelSpeed = 420;
       const travelDuration = Math.max(0.35, distance / travelSpeed);
-      const trailLife = Math.max(travelDuration + 0.25, 0.6);
-      const trail = document.createElement('div');
-      trail.className = 'meteor-trail';
-      trail.style.left = `${startX}px`;
-      trail.style.top = `${startY}px`;
-      const baseTrailTransform = `translateY(-50%) rotate(${angle}rad)`;
-      trail.style.transform = `${baseTrailTransform} scaleX(0)`;
-      trail.style.setProperty('--meteor-trail-length', `${Math.max(distance + size * 0.6, 80)}px`);
-      trail.style.setProperty('--meteor-trail-life', `${trailLife}s`);
-      trail.style.setProperty('--meteor-travel-duration', `${travelDuration}s`);
-      gridFxLayerEl.appendChild(trail);
       meteor.style.setProperty('--meteor-travel-duration', `${travelDuration}s`);
       meteor.style.transform = `translate(${startX - half}px, ${startY - half}px) rotate(${angle}rad) scale(0.45)`;
       gridFxLayerEl.appendChild(meteor);
+      spawnMeteorEcho(startX, startY, size, meteor);
       let impacted = false;
+      const travelMs = travelDuration * 1000;
+      const echoInterval = 80;
+      let echoRaf = null;
+      let echoStartTime = null;
+      let lastEchoAt = -Infinity;
+      const runEcho = (now) => {
+        if(impacted) return;
+        if(echoStartTime === null){
+          echoStartTime = now;
+        }
+        const elapsed = now - echoStartTime;
+        const progress = Math.min(1, elapsed / travelMs);
+        if(elapsed - lastEchoAt >= echoInterval){
+          const echoX = startX + dx * progress;
+          const echoY = startY + dy * progress;
+          spawnMeteorEcho(echoX, echoY, size, meteor);
+          lastEchoAt = elapsed;
+        }
+        if(progress < 1){
+          echoRaf = requestAnimationFrame(runEcho);
+        }
+      };
       const impactNow = () => {
         if(impacted) return;
         impacted = true;
-        trail.style.transform = `${baseTrailTransform} scaleX(1)`;
+        if(echoRaf !== null){
+          cancelAnimationFrame(echoRaf);
+          echoRaf = null;
+        }
+        spawnMeteorEcho(centerX, centerY, size, meteor);
         meteor.classList.add('fading');
         triggerMeteorImpact(centerX, centerY, onImpact);
         setTimeout(()=>meteor.remove(), 360);
-        setTimeout(()=>trail.remove(), Math.round((trailLife + 0.2) * 1000));
       };
       requestAnimationFrame(()=>{
         requestAnimationFrame(()=>{
           meteor.addEventListener('transitionend', impactNow, { once: true });
-          trail.style.transform = `${baseTrailTransform} scaleX(1)`;
           meteor.style.transform = `translate(${centerX - half}px, ${centerY - half}px) rotate(${angle}rad) scale(1.18)`;
+          echoRaf = requestAnimationFrame(runEcho);
         });
       });
       setTimeout(impactNow, (travelDuration + 0.25) * 1000);


### PR DESCRIPTION
## Summary
- remove the pre-travel meteor trail indicator
- add short-lived translucent red pentagon echoes that follow the meteor and render behind it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e154209b00833297e6be0506401e9c