### PR TITLE
Add meteor warning effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
     .hp>div{height:100%;background:linear-gradient(90deg,#34d399,#f59e0b);width:100%}
 
     .meteor-effect{position:absolute;width:42px;height:42px;clip-path:polygon(18% 4%,82% 0%,100% 32%,76% 56%,88% 86%,46% 100%,12% 82%,0% 38%);background:radial-gradient(circle at 32% 28%,rgba(255,237,205,.92) 0%,rgba(255,163,120,.9) 38%,rgba(214,59,32,.9) 68%,rgba(94,18,8,.78) 100%);filter:drop-shadow(0 0 22px rgba(255,106,64,.68)) drop-shadow(0 0 46px rgba(219,54,24,.45));transform-origin:center;opacity:.96;transition:transform var(--meteor-travel-duration,0.8s) linear,opacity .28s ease-out;animation:meteor-core-pulse .52s linear infinite alternate;pointer-events:none;mix-blend-mode:screen;z-index:6;}
-    .meteor-tracer{position:absolute;width:var(--meteor-tracer-size,42px);height:var(--meteor-tracer-size,42px);clip-path:polygon(50% 6%,93% 38%,76% 94%,24% 94%,7% 38%);background:radial-gradient(circle,rgba(255,76,76,.36) 0%,rgba(157,24,24,.28) 58%,rgba(118,18,18,0) 100%);border:1px solid rgba(255,92,92,.32);border-radius:12%;transform:translate(-50%,-50%) rotate(var(--meteor-tracer-rotation,0deg)) scale(1);opacity:.7;pointer-events:none;mix-blend-mode:screen;transition:opacity .22s ease-out,transform .22s ease-out;z-index:4;}
-    .meteor-tracer.fade{opacity:0;transform:translate(-50%,-50%) rotate(var(--meteor-tracer-rotation,0deg)) scale(.72);}
+    .meteor-warning{position:absolute;width:var(--meteor-warning-size,58px);height:var(--meteor-warning-size,58px);clip-path:polygon(50% 6%,90% 32%,74% 94%,26% 94%,10% 32%);background:radial-gradient(circle,rgba(255,84,84,.55) 0%,rgba(185,28,28,.35) 52%,rgba(120,6,6,0) 100%);border:1px solid rgba(248,113,113,.45);transform:translate(-50%,-50%) scale(.78);opacity:0;pointer-events:none;mix-blend-mode:screen;animation:meteor-warning-pulse .28s ease-out forwards;z-index:4;}
+    @keyframes meteor-warning-pulse{0%{opacity:.7;transform:translate(-50%,-50%) scale(.78);}100%{opacity:0;transform:translate(-50%,-50%) scale(1.22);}}
     .meteor-echo{position:absolute;width:var(--meteor-echo-size,42px);height:var(--meteor-echo-size,42px);clip-path:polygon(50% 4%,95% 38%,78% 96%,22% 96%,5% 38%);background:radial-gradient(circle,rgba(255,72,72,.34) 0%,rgba(145,16,16,.28) 68%,rgba(115,12,12,0) 100%);border:1px solid rgba(255,116,116,.48);border-radius:50%;pointer-events:none;opacity:.55;mix-blend-mode:screen;transform-origin:center;transition:opacity .22s ease-out,transform .22s ease-out;z-index:5;}
     .meteor-effect::before{content:'';position:absolute;inset:-18% 20% -42% 10%;background:linear-gradient(180deg,rgba(255,198,142,.65) 0%,rgba(255,134,76,.35) 55%,rgba(124,28,8,0) 100%);filter:blur(4px);opacity:.85;transform:rotate(-6deg);border-radius:50%;clip-path:inherit;}
     .meteor-effect::after{content:'';position:absolute;inset:14% -48% 12% 28%;background:radial-gradient(circle at 0% 50%,rgba(255,160,120,.85) 0%,rgba(255,118,72,.45) 40%,rgba(255,98,48,0) 75%);filter:blur(2px);opacity:.9;clip-path:inherit;}
@@ -1738,22 +1738,20 @@ section[id^="tab-"].active{ display:block; }
 
     function spawnMeteorTracer(x, y, size, meteorEl){
       if(!gridFxLayerEl) return;
-      const tracer = document.createElement('div');
-      tracer.className = 'meteor-tracer';
-      tracer.style.left = x + 'px';
-      tracer.style.top = y + 'px';
+      const warning = document.createElement('div');
+      warning.className = 'meteor-warning';
+      warning.style.left = x + 'px';
+      warning.style.top = y + 'px';
       if(Number.isFinite(size)){
-        tracer.style.setProperty('--meteor-tracer-size', `${size}px`);
+        const warningSize = Math.max(0, size * 1.35);
+        warning.style.setProperty('--meteor-warning-size', `${warningSize}px`);
       }
-      const rotation = (Math.random() * 360) - 180;
-      tracer.style.setProperty('--meteor-tracer-rotation', `${rotation}deg`);
       if(meteorEl && meteorEl.parentNode === gridFxLayerEl){
-        gridFxLayerEl.insertBefore(tracer, meteorEl);
+        gridFxLayerEl.insertBefore(warning, meteorEl);
       } else {
-        gridFxLayerEl.appendChild(tracer);
+        gridFxLayerEl.appendChild(warning);
       }
-      requestAnimationFrame(()=>tracer.classList.add('fade'));
-      setTimeout(()=>tracer.remove(), 320);
+      setTimeout(()=>warning.remove(), 280);
     }
 
     function spawnMeteorEcho(x, y, size, meteorEl, options = {}){


### PR DESCRIPTION
## Summary
- replace the meteor tracer overlay with a short-lived red pentagonal warning that marks the meteor's current location before impact
- update styling to animate the warning pulse and drop the previous square overlay around the meteor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e1dfeb4c83328c0667d2aff0a3fc